### PR TITLE
Add full steps data

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ except Exception:  # pylint: disable=broad-except
     print("Unknown error occurred during Garmin Connect Client get stats")
     quit()
 
+"""
+Get steps data
+"""
+try:
+    print(client.get_steps_data(today.isoformat()))
+except (
+    GarminConnectConnectionError,
+    GarminConnectAuthenticationError,
+    GarminConnectTooManyRequestsError,
+) as err:
+    print("Error occurred during Garmin Connect Client get heart rates: %s" % err)
+    quit()
+except Exception:  # pylint: disable=broad-except
+    print("Unknown error occurred during Garmin Connect Client get steps data")
+    quit()
 
 """
 Get heart rate data

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -19,6 +19,7 @@ class Garmin(object):
     See https://connect.garmin.com/
     """
     url_user_summary = MODERN_URL + '/proxy/usersummary-service/usersummary/daily/'
+    url_user_summary_chart = MODERN_URL + '/proxy/wellness-service/wellness/dailySummaryChart/'
     url_heartrates = MODERN_URL + '/proxy/wellness-service/wellness/dailyHeartRate/'
     url_sleepdata = MODERN_URL + '/proxy/wellness-service/wellness/dailySleepData/'
     url_body_composition = MODERN_URL + '/proxy/weight-service/weight/daterangesnapshot'
@@ -239,6 +240,15 @@ class Garmin(object):
         self.logger.debug("Fetching sleep data with url %s", sleepurl)
 
         return self.fetch_data(sleepurl)
+
+    def get_steps_data(self, cdate):   # cDate = 'YYYY-mm-dd'
+        """
+        Fetch available steps data
+        """
+        steps_url = self.url_user_summary_chart + self.display_name + '?date=' + cdate
+        self.logger.debug("Fetching steps data with url %s", steps_url)
+
+        return self.fetch_data(steps_url)
 
 
     def get_body_composition(self, cdate):   # cDate = 'YYYY-mm-dd'

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -19,7 +19,6 @@ class Garmin(object):
     See https://connect.garmin.com/
     """
     url_user_summary = MODERN_URL + '/proxy/usersummary-service/usersummary/daily/'
-    url_user_summary_chart = MODERN_URL + '/proxy/wellness-service/wellness/dailySummaryChart/'
     url_heartrates = MODERN_URL + '/proxy/wellness-service/wellness/dailyHeartRate/'
     url_sleepdata = MODERN_URL + '/proxy/wellness-service/wellness/dailySleepData/'
     url_body_composition = MODERN_URL + '/proxy/weight-service/weight/daterangesnapshot'
@@ -240,15 +239,6 @@ class Garmin(object):
         self.logger.debug("Fetching sleep data with url %s", sleepurl)
 
         return self.fetch_data(sleepurl)
-
-    def get_steps_data(self, cdate):   # cDate = 'YYYY-mm-dd'
-        """
-        Fetch available steps data
-        """
-        steps_url = self.url_user_summary_chart + self.display_name + '?date=' + cdate
-        self.logger.debug("Fetching steps data with url %s", steps_url)
-
-        return self.fetch_data(steps_url)
 
 
     def get_body_composition(self, cdate):   # cDate = 'YYYY-mm-dd'


### PR DESCRIPTION
Currently the library support only getting the user summary.
With this PR, we will be able to fetch also the steps and activity level by 15 minutes.
`[{'startGMT': '2020-07-08T07:00:00.0', 'endGMT': '2020-07-08T07:15:00.0', 'steps': 9, 'primaryActivityLevel': 'sedentary', 'activityLevelConstant': True}, {'startGMT': '2020-07-08T07:15:00.0', 'endGMT': '2020-07-08T07:30:00.0', 'steps': 51, 'primaryActivityLevel': 'sedentary', 'activityLevelConstant': True}]` 