### PR TITLE
Adding get_activities_by_date method

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -273,6 +273,41 @@ class Garmin(object):
 
         return self.fetch_data(activitiesurl)
 
+    def get_activities_by_date(self, startdate: str, enddate: str, activitytype = "" ) -> list[json]:
+        """
+        Fetch available activities between specific dates
+
+        :param startdate: String in the format YYYY-MM-DD
+        :param enddate: String in the format YYYY-MM-DD
+        :param activitytype: (Optional) Type of activity you are searching
+                             Possible values are [cycling, running, swimming,
+                             multi_sport, fitness_equipment, hiking, walking, other]
+        :return: list of JSON activities
+        """
+
+        activities = []
+        start = 0
+        limit = 20
+        returndata = True
+        # mimicking the behavior of the web interface that fetches 20 activities at a time
+        # and automatically loads more on scroll
+        if activitytype:
+            activityslug = "&activityType=" + str(activitytype)
+        else:
+            activityslug = ""
+        while returndata:
+            activitiesurl = self.url_activities + '?startDate=' + str(startdate) + '&endDate=' + str(
+                            enddate) + '&start=' + str(start) + '&limit=' + str(limit) + activityslug
+            self.logger.debug("Fetching activities with url %s", activitiesurl)
+            act = self.fetch_data(activitiesurl)
+            if act:
+                activities.extend(act)
+                start = start + limit
+            else:
+                returndata = False
+
+        return activities
+
     def get_excercise_sets(self, activity_id):
         activity_id = str(activity_id)
         exercisesetsurl = f"{self.url_exercise_sets}{activity_id}/exerciseSets"


### PR DESCRIPTION
This method comes in handy when you want to search for specific activities between specific dates of a specific type.

The method mimics the way how the web interface works fetching 20 activities at a time and automatically loading more on scroll. Particularly useful when you want to search for a long date range (like an entire year).

Usage:

activities = client.get_activities_by_date('2020-12-01', '2020-12-31')

or 

activities = client.get_activities_by_date('2020-12-01', '2020-12-31', 'cycling')