### PR TITLE
Add possibility for a wider start / end range to get body composition

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -282,12 +282,14 @@ class Garmin(object):
 
         return self.fetch_data(steps_url)
 
-    def get_body_composition(self, cdate):   # cDate = 'YYYY-mm-dd'
+    def get_body_composition(self, startdate, enddate=None):   # date = 'YYYY-mm-dd'
         """
         Fetch available body composition data (only for cDate)
         """
+        if enddate is None:
+            enddate = startdate
         bodycompositionurl = self.url_body_composition + \
-            '?startDate=' + cdate + '&endDate=' + cdate
+            '?startDate=' + str(startdate) + '&endDate=' + str(enddate)
         self.logger.debug(
             "Fetching body composition with url %s", bodycompositionurl)
 


### PR DESCRIPTION
This PR addresses #34: enable the possibility for a different start and end date for get body composition.
I have enabled backwards compatibility to avoid any breaking changes with original function.