### PR TITLE
Fix: Add an extra regex expression to account for updated profile info response

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -158,10 +158,12 @@ class Garmin(object):
         """
         Find and return json data
         """
-        found = re.search(key + r" = (.*);", html, re.M)
-        if found:
-            text = found.group(1).replace('\\"', '"')
-            return json.loads(text)
+
+        regex_list = [re.search(key + r" = (.*);", html, re.M), re.search(key + r" = JSON.parse\(\"(.*)\"\);", html, re.M)]
+        for found in regex_list:
+            if found:
+                text = found.group(1).replace('\\"', '"')
+                return json.loads(text)
 
     def fetch_data(self, url):
         """

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -158,7 +158,7 @@ class Garmin(object):
         """
         Find and return json data
         """
-        found = re.search(key + r" = JSON.parse\(\"(.*)\"\);", html, re.M)
+        found = re.search(key + r" = (.*);", html, re.M)
         if found:
             text = found.group(1).replace('\\"', '"')
             return json.loads(text)


### PR DESCRIPTION
This PR is to address issue #59 that I have experienced. 
Given that I am not aware of how widespread this issue is, I have updated the parse_json function to include the regex that was suggested by @mcshosho while still retaining the original one as an alternative.