### PR TITLE
change session check to session_data check in login method

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -216,10 +216,7 @@ class Garmin:
         return None
 
     def login(self):
-        print(f'session: {self.session}')
-        print('skipping session login..')
-        return self.authenticate()
-        if (self.session is None):
+        if (self.session_data is None):
             return self.authenticate()
         else:
             return self.login_session()
@@ -228,7 +225,6 @@ class Garmin:
         logger.debug("login with cookies")
 
         session_display_name = self.session_data['display_name']
-        # breakpoint()
         params= self.session_data['params']
         logger.debug("Set cookies in session")
         self.modern_rest_client.set_cookies( requests.utils.cookiejar_from_dict(self.session_data['session_cookies']))

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -216,6 +216,9 @@ class Garmin:
         return None
 
     def login(self):
+        print(f'session: {self.session}')
+        print('skipping session login..')
+        return self.authenticate()
         if (self.session is None):
             return self.authenticate()
         else:
@@ -225,6 +228,7 @@ class Garmin:
         logger.debug("login with cookies")
 
         session_display_name = self.session_data['display_name']
+        # breakpoint()
         params= self.session_data['params']
         logger.debug("Set cookies in session")
         self.modern_rest_client.set_cookies( requests.utils.cookiejar_from_dict(self.session_data['session_cookies']))


### PR DESCRIPTION
Thanks for creating this package!  Not sure if there is a better way but seems like the session code introduced in the last pull request checks if `self.session` is `None`, but perhaps should be checking if `self.session_data` is `None` (since `session` is instantiated in the `Garmin` class on line 191 [here](https://github.com/cyberjunky/python-garminconnect/blob/master/garminconnect/__init__.py#L191)) but doesn't contain anything from what I can tell.  This quick fix seems to fix things.  A better fix might be only instantiate a session if `session_data` is actually passed to the class.
Really cool that this package works so well!