### PR TITLE
Error on startup when account has devices without alarm support

### DIFF
--- a/example.py
+++ b/example.py
@@ -76,6 +76,7 @@ menu_options = {
     "u": "Get active goals",
     "v": "Get future goals",
     "w": "Get past goals",
+    "y": "Get all Garmin device alarms",
     "x": f"Get Heart Rate Variability data (HRV) for '{today.isoformat()}'",
     "G": f"Get Gear'",
     "Z": "Logout Garmin Connect portal",
@@ -384,6 +385,14 @@ def switch(api, i):
                 # Get past goals
                 goals = api.get_goals("past")
                 display_json("api.get_goals(\"past\")", goals)
+            
+            # ALARMS
+            elif i == "y":
+                # Get Garmin device alarms
+                alarms = api.get_device_alarms()
+                for alarm in alarms:
+                    alarm_id = alarm["alarmId"]
+                    display_json(f"api.get_device_alarms({alarm_id})", alarm)
 
             elif i == "x":
                 # Get Heart Rate Variability (hrv) data

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -632,7 +632,9 @@ class Garmin:
         devices = self.get_devices()
         for device in devices:
             device_settings = self.get_device_settings(device["deviceId"])
-            alarms += device_settings["alarms"]
+            device_alarms = device_settings["alarms"]
+            if device_alarms is not None:
+                alarms += device_alarms
         return alarms
 
     def get_device_last_used(self):


### PR DESCRIPTION
Hey!
I have been trying to setup this integration for quite some time, now I finally got the time to look at it and I managed to find out what was the issue.

---

After applying my credentials and when the integration tries to startup but then I got this error _(then it loops until Garmin blocks all requests)_

```
Logger: custom_components.garmin_connect
Source: custom_components/garmin_connect/__init__.py:99
Integration: Garmin Connect ([documentation](https://github.com/cyberjunky/home-assistant-garmin_connect), [issues](https://github.com/cyberjunky/home-assistant-garmin_connect/issues))
First occurred: 08:24:11 (17 occurrences)
Last logged: 10:19:32

Unexpected error fetching garmin_connect data: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 225, in _async_refresh
    self.data = await self._async_update_data()
  File "/config/custom_components/garmin_connect/__init__.py", line 99, in _async_update_data
    alarms = await self.hass.async_add_executor_job(self._api.get_device_alarms)
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/site-packages/garminconnect/__init__.py", line 425, in get_device_alarms
    alarms += device_settings["alarms"]
TypeError: 'NoneType' object is not iterable
```

So I debugged the source code locally and it seems that, I have a device (Garmin Vector 3 pedals) that returns `alarms: null` inside the `device_settings`, making the current code crash and the whole startup process fails. Simply adding this null check fixes this by simply ignoring that device.

Please have a look when you have time, and let me now if I need to update something