### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ def switch(api, i):
         ) as err:
             logger.error("Error occurred: %s", err)
         except KeyError:
-            # Invalid menu option choosen
+            # Invalid menu option chosen
             pass
     else:
         print("Could not login to Garmin Connect, try again later.")

--- a/example.py
+++ b/example.py
@@ -438,7 +438,7 @@ def switch(api, i):
         ) as err:
             logger.error("Error occurred: %s", err)
         except KeyError:
-            # Invalid menu option choosen
+            # Invalid menu option chosen
             pass
     else:
         print("Could not login to Garmin Connect, try again later.")


### PR DESCRIPTION
% [`codespell`](https://pypi.org/project/codespell/)
```
./README.md:450: choosen ==> chosen
./example.py:441: choosen ==> chosen
```