### PR TITLE
Replace .text with .json() in garmin.get_hrv_data()

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -602,7 +602,7 @@ class Garmin:
         url = f"{self.garmin_connect_hrv_url}/{cdate}"
         logger.debug("Requesting Heart Rate Variability (hrv) data")
 
-        return self.modern_rest_client.get(url).text #.json()
+        return self.modern_rest_client.get(url).json()
 
     def get_training_readiness(self, cdate: str) -> Dict[str, Any]:
         """Return training readiness data for current user."""


### PR DESCRIPTION
Related to https://github.com/cyberjunky/python-garminconnect/issues/117 which I just opened -- `garmin.get_hrv_data()` has a last line of 

`        return self.modern_rest_client.get(url).text #.json()` 

instead of

`        return self.modern_rest_client.get(url).json()`