### PR TITLE
Add blood pressure endpoint and function

### DIFF
--- a/example.py
+++ b/example.py
@@ -224,7 +224,7 @@ def switch(api, i):
             elif i == "/":
                 # Get daily body battery data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
                 display_json(f"api.get_body_battery('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
-            elif i == "bp":
+            elif i == "?":
                 # Get daily blood pressure data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
                 display_json(f"api.get_blood_pressure('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
             elif i == "-":

--- a/example.py
+++ b/example.py
@@ -55,6 +55,7 @@ menu_options = {
     "0": f"Get training readiness data for '{today.isoformat()}'",
     "-": f"Get daily step data for '{startdate.isoformat()}' to '{today.isoformat()}'",
     "/": f"Get body battery data for '{startdate.isoformat()}' to '{today.isoformat()}'",
+    "?": f"Get blood pressure data for '{startdate.isoformat()}' to '{today.isoformat()}'",
     ".": f"Get training status data for '{today.isoformat()}'",
     "a": f"Get resting heart rate data for {today.isoformat()}'",
     "b": f"Get hydration data for '{today.isoformat()}'",
@@ -223,6 +224,9 @@ def switch(api, i):
             elif i == "/":
                 # Get daily body battery data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
                 display_json(f"api.get_body_battery('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
+            elif i == "bp":
+                # Get daily blood pressure data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
+                display_json(f"api.get_blood_pressure('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
             elif i == "-":
                 # Get daily step data for 'YYYY-MM-DD'
                 display_json(f"api.get_daily_steps('{startdate.isoformat()}, {today.isoformat()}')", api.get_daily_steps(startdate.isoformat(), today.isoformat()))

--- a/example.py
+++ b/example.py
@@ -226,7 +226,7 @@ def switch(api, i):
                 display_json(f"api.get_body_battery('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
             elif i == "?":
                 # Get daily blood pressure data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
-                display_json(f"api.get_blood_pressure('{startdate.isoformat()}, {today.isoformat()}')", api.get_body_battery(startdate.isoformat(), today.isoformat()))
+                display_json(f"api.get_blood_pressure('{startdate.isoformat()}, {today.isoformat()}')", api.get_blood_pressure(startdate.isoformat(), today.isoformat()))
             elif i == "-":
                 # Get daily step data for 'YYYY-MM-DD'
                 display_json(f"api.get_daily_steps('{startdate.isoformat()}, {today.isoformat()}')", api.get_daily_steps(startdate.isoformat(), today.isoformat()))

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -179,6 +179,10 @@ class Garmin:
             "proxy/wellness-service/wellness/bodyBattery/reports/daily"
         )
 
+        self.garmin_connect_blood_pressure_endpoint = (
+            "proxy/bloodpressure-service/bloodpressure/range"
+        )
+
         self.garmin_connect_goals_url = "proxy/goal-service/goal/goals"
 
         self.garmin_connect_rhr_url = "proxy/userstats-service/wellness/daily"
@@ -498,6 +502,17 @@ class Garmin:
         url = self.garmin_connect_daily_body_battery_url
         params = {"startDate": str(startdate), "endDate": str(enddate)}
         logger.debug("Requesting body battery data")
+
+        return self.modern_rest_client.get(url, params=params).json()
+
+    def get_blood_pressure(self, startdate: str, enddate=None) -> Dict[str, Any]:
+        """Returns blood pressure by day for 'startdate' format 'YYYY-MM-DD' through enddate 'YYYY-MM-DD'"""
+
+        if enddate is None:
+            enddate = startdate
+        url = f"{self.garmin_connect_blood_pressure_endpoint}/{startdate}/{enddate}"
+        params = {"includeAll": True}
+        logger.debug("Requesting blood pressure data")
 
         return self.modern_rest_client.get(url, params=params).json()
 


### PR DESCRIPTION
Adds a get_blood_pressure function that calls a newly added blood pressure URL and returns blood pressure summaries and detailed measurements for each day.

There may be a better way to get an individual day, but as this works with a single date, it's fine.

Days without blood pressure measurements do not appear in the data.




```python
-------------------- api.get_blood_pressure('2023-01-19, 2023-01-26') --------------------
{
    'from': '2023-01-19',
    'until': '2023-01-26',
    'measurementSummaries':
        [
            {
                'startDate': '2023-01-26',
                'endDate': '2023-01-26',
                'highSystolic': 119,
                'highDiastolic': 72,
                'lowSystolic': 118,
                'lowDiastolic': 71,
                'numOfMeasurements': 3,
                'category': 'NORMAL',
                'measurements':
                    [
                        {'version': ****,
                         'systolic': **,
                         'diastolic': **,
                         'pulse': None,
                         'multiMeasurement': False,
                         'notes': '',
                         'sourceType': 'MANUAL',
                         'measurementTimestampLocal': '2023-01-26T17:34:50.822',
                         'measurementTimestampGMT': '2023-01-26T22:34:50.822',
                         'category': 'NORMAL'
                         },
                         ...
                    ]
            },
            {
                'startDate': '2023-01-23',
                'endDate': '2023-01-23',
                'highSystolic': 134,
                'highDiastolic': 78,
                'lowSystolic': 134,
                'lowDiastolic': 78,
                'numOfMeasurements': 1,
                'category': 'STAGE_1_HIGH',
                'measurements':
                    [
                        {
                            'version': ****,
                            'systolic': **,
                            'diastolic': **,
                            'pulse': None,
                            'multiMeasurement': False,
                            'notes': '',
                            'sourceType': 'MANUAL',
                            'measurementTimestampLocal': '2023-01-23T17:32:18.728',
                            'measurementTimestampGMT': '2023-01-23T22:32:18.728',
                            'category': 'STAGE_1_HIGH'
                        }
                    ]
            },
            ...
        ],
    'categoryStats': {
                        'from': '2023-01-19',
                        'until': '2023-01-26',
                        'noOfDaysNormal': 1,
                        'noOfDaysElevated': 2,
                        'noOfDaysStage1': 1,
                        'noOfDaysStage2': 1,
                        'noOfDaysCritical': 0
                      }
}
```
