### PR TITLE
Add floors endpoint, function, and example

### DIFF
--- a/example.py
+++ b/example.py
@@ -55,6 +55,7 @@ menu_options = {
     "0": f"Get training readiness data for '{today.isoformat()}'",
     "-": f"Get daily step data for '{startdate.isoformat()}' to '{today.isoformat()}'",
     "/": f"Get body battery data for '{startdate.isoformat()}' to '{today.isoformat()}'",
+    "!": f"Get floors data for '{startdate.isoformat()}'",
     ".": f"Get training status data for '{today.isoformat()}'",
     "a": f"Get resting heart rate data for {today.isoformat()}'",
     "b": f"Get hydration data for '{today.isoformat()}'",
@@ -226,6 +227,9 @@ def switch(api, i):
             elif i == "-":
                 # Get daily step data for 'YYYY-MM-DD'
                 display_json(f"api.get_daily_steps('{startdate.isoformat()}, {today.isoformat()}')", api.get_daily_steps(startdate.isoformat(), today.isoformat()))
+            elif i == "!":
+                # Get daily floors data for 'YYYY-MM-DD'
+                display_json(f"api.get_floors_data('{today.isoformat()}')", api.get_floors_data(today.isoformat()))
             elif i == ".":
                 # Get training status data for 'YYYY-MM-DD'
                 display_json(f"api.get_training_status('{today.isoformat()}')", api.get_training_status(today.isoformat()))

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -459,11 +459,11 @@ class Garmin:
 
         return self.modern_rest_client.get(url, params=params).json()
 
-    def get_floors_data(self, cdate):
-        """Fetch available floors data 'cDate' format 'YYYY-MM-DD'."""
+    def get_floors_climbed(self, cdate):
+        """Fetch available floors climbed 'cDate' format 'YYYY-MM-DD'."""
 
         url = f'{self.garmin_connect_floors_chart_daily_url}/{cdate}'
-        logger.debug("Requesting floors data")
+        logger.debug("Requesting floors climbed")
 
         return self.modern_rest_client.get(url).json()
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -192,6 +192,9 @@ class Garmin:
         self.garmin_connect_user_summary_chart = (
             "proxy/wellness-service/wellness/dailySummaryChart"
         )
+        self.garmin_connect_floors_chart_daily_url = (
+            "proxy/wellness-service/wellness/floorsChartData/daily"
+        )
         self.garmin_connect_heartrates_daily_url = (
             "proxy/wellness-service/wellness/dailyHeartRate"
         )
@@ -451,6 +454,14 @@ class Garmin:
         logger.debug("Requesting steps data")
 
         return self.modern_rest_client.get(url, params=params).json()
+
+    def get_floors_data(self, cdate):
+        """Fetch available floors data 'cDate' format 'YYYY-MM-DD'."""
+
+        url = f'{self.garmin_connect_floors_chart_daily_url}/{cdate}'
+        logger.debug("Requesting floors data")
+
+        return self.modern_rest_client.get(url).json()
 
     def get_daily_steps(self, start, end):
         """Fetch available steps data 'start' and 'end' format 'YYYY-MM-DD'."""


### PR DESCRIPTION
Adds a function to get the details of floors ascended / descended for a day.
I found the graph on https://connect.garmin.com/modern/daily-summary/2023-01-29, and did not find a way to get more than a day at a time

Response from the API (this wasn't a very active day ...)
```
-------------------- api.get_floors_data('2023-01-29') --------------------
{
    "startTimestampGMT": "2023-01-28T23:00:00.0",
    "endTimestampGMT": "2023-01-29T07:38:00.0",
    "startTimestampLocal": "2023-01-29T00:00:00.0",
    "endTimestampLocal": "2023-01-29T08:38:00.0",
    "floorsValueDescriptorDTOList": [
        {
            "key": "startTimeGMT",
            "index": 0
        },
        {
            "key": "endTimeGMT",
            "index": 1
        },
        {
            "key": "floorsAscended",
            "index": 2
        },
        {
            "key": "floorsDescended",
            "index": 3
        }
    ],
    "floorValuesArray": [
        [
            "2023-01-28T23:00:00.0",
            "2023-01-28T23:15:00.0",
            0,
            0
        ],
        [
            "2023-01-28T23:15:00.0",
            "2023-01-28T23:30:00.0",
            0,
            0
        ],
        ...
        [
            "2023-01-29T07:15:00.0",
            "2023-01-29T07:30:00.0",
            0,
            0
        ],
        [
            "2023-01-29T07:30:00.0",
            "2023-01-29T07:45:00.0",
            0,
            0
        ]
    ]
}
---------------------------------------------------------------------------
```