### PR TITLE
Add get_inprogress_virtual_challenges method

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -175,6 +175,9 @@ class Garmin:
         self.garmin_connect_non_completed_badge_challenges_url = (
             "proxy/badgechallenge-service/badgeChallenge/non-completed"
         )
+        self.garmin_connect_inprogress_virtual_challenges_url = (
+            "proxy/badgechallenge-service/virtualChallenge/inProgress"
+        )
         self.garmin_connect_daily_sleep_url = (
             "proxy/wellness-service/wellness/dailySleepData"
         )
@@ -615,6 +618,15 @@ class Garmin:
         url = self.garmin_connect_non_completed_badge_challenges_url
         params = {"start": str(start), "limit": str(limit)}
         logger.debug("Requesting badge challenges for user")
+
+        return self.modern_rest_client.get(url, params=params).json()
+
+    def get_inprogress_virtual_challenges(self, start, limit) -> Dict[str, Any]:
+        """Return in-progress virtual challenges for current user."""
+
+        url = self.garmin_connect_inprogress_virtual_challenges_url
+        params = {"start": str(start), "limit": str(limit)}
+        logger.debug("Requesting in-progress virtual challenges for user")
 
         return self.modern_rest_client.get(url, params=params).json()
 


### PR DESCRIPTION
Add method to retrieve information about "virtual" challenges.
These challenges don't have a start/end date.

In the app, they are called "expeditions".