### PR TITLE
Fix testing by using correct env variable names

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -159,12 +159,12 @@ class Garmin:
     def download(self, path, **kwargs):
         return self.garth.download(path, **kwargs)
 
-    def login(self, /, garth_home: Optional[str] = None):
+    def login(self, /, tokenstore: Optional[str] = None):
         """Log in using Garth"""
-        garth_home = garth_home or os.getenv("GARTH_HOME")
+        tokenstore = tokenstore or os.getenv("GARMINTOKENS")
 
-        if garth_home:
-            self.garth.load(garth_home)
+        if tokenstore:
+            self.garth.load(tokenstore)
         else:
             self.garth.login(self.username, self.password)
 

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     long_description=readme,
     url="https://github.com/cyberjunky/python-garminconnect",
     packages=["garminconnect"],
-    version="0.2.1"
+    version="0.2.2"
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ import pytest
 
 @pytest.fixture
 def vcr(vcr):
-    if "GARTH_HOME" not in os.environ:
-        vcr.record_mode = "none"
+    assert "GARMINTOKENS" in os.environ
     return vcr
 
 


### PR DESCRIPTION
This attempts to resolve the [failing tests](https://github.com/cyberjunky/python-garminconnect/pull/144#issuecomment-1718935655)

@cyberjunky the issue was you and I using different env variable names for the session. As long as you have an active session, the tests will all correctly. I adopted the same naming convention as `example.py`. Let me know if this works.