### PR TITLE
Introduces ability to add blood pressure

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -73,6 +73,11 @@ class Garmin:
         self.garmin_connect_blood_pressure_endpoint = (
             "/bloodpressure-service/bloodpressure/range"
         )
+
+        self.garmin_connect_set_blood_pressure_endpoint = (
+            "/bloodpressure-service/bloodpressure"
+        )
+
         self.garmin_connect_endurance_score_url = (
             "/metrics-service/metrics/endurancescore"
         )
@@ -354,6 +359,32 @@ class Garmin:
         logger.debug("Requesting body battery data")
 
         return self.connectapi(url, params=params)
+
+    def set_blood_pressure(
+        self, systolic: int, diastolic: int, pulse:int,
+        timestamp: str = "", notes: str = ""
+    ):
+        """
+        Add blood pressure measurement
+        """
+
+        url = f"{self.garmin_connect_set_blood_pressure_endpoint}"
+        dt = datetime.fromisoformat(timestamp) if timestamp else datetime.now()
+        # Apply timezone offset to get UTC/GMT time
+        dtGMT = dt - dt.astimezone().tzinfo.utcoffset(dt)
+        payload = {
+            "measurementTimestampLocal": dt.isoformat()[:22] + ".00",
+            "measurementTimestampGMT": dtGMT.isoformat()[:22] + ".00",
+            "systolic": systolic,
+            "diastolic": diastolic,
+            "pulse": pulse,
+            "sourceType": "MANUAL",
+            "notes": notes
+        }
+
+        logger.debug("Adding blood pressure")
+
+        return self.garth.post("connectapi", url, json=payload)
 
     def get_blood_pressure(
         self, startdate: str, enddate=None


### PR DESCRIPTION
Provides the ability to set a blood pressure data

```yaml
from getpass import getpass
import garminconnect

email = input("Enter email address: ")
password = getpass("Enter password: ")

garmin = garminconnect.Garmin(email, password)
garmin.login()


// passing a timestamp
In [4]: garmin.set_blood_pressure(112,72,72,timestamp="2023-10-16T23:10:15")
Out[4]: <Response [200]>

// using `datetime.now()`
In [5]: garmin.set_blood_pressure(113,73,73)
Out[5]: <Response [200]>

// passing notes
In [6]: garmin.set_blood_pressure(114,74,74,notes="testing via api")
Out[6]: <Response [200]>
```

![image](https://github.com/cyberjunky/python-garminconnect/assets/809840/4c8cf743-aacd-489f-a055-21261c4ea5b2)


Fixes: https://github.com/cyberjunky/python-garminconnect/issues/167