### PR TITLE
Get and Delete Activities by ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ MANIFEST
 *.manifest
 *.spec
 
+# PyCharm idea folder
+.idea/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -134,3 +137,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Ignore folder for local testing
+ignore/

--- a/example.py
+++ b/example.py
@@ -518,10 +518,10 @@ def switch(api, i):
                     api.get_activity_gear(first_activity_id),
                 )
 
-                # Activity self evaluation data for activity id
+                # Activity data for activity id
                 display_json(
-                    f"api.get_activity_evaluation({first_activity_id})",
-                    api.get_activity_evaluation(first_activity_id),
+                    f"api.get_activity({first_activity_id})",
+                    api.get_activity(first_activity_id),
                 )
 
                 # Get exercise sets in case the activity is a strength_training

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1022,13 +1022,13 @@ class Garmin:
 
         return self.connectapi(url)
 
-    def get_activity_evaluation(self, activity_id):
-        """Return activity self evaluation details."""
+    def get_activity(self, activity_id):
+        """Return activity summary, including basic splits."""
 
         activity_id = str(activity_id)
         url = f"{self.garmin_connect_activity}/{activity_id}"
         logger.debug(
-            "Requesting self evaluation data for activity id %s", activity_id
+            "Requesting activity summary data for activity id %s", activity_id
         )
 
         return self.connectapi(url)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -161,7 +161,6 @@ class Garmin:
             "/activity-service/activity"
         )
 
-
         self.garth = garth.Client(
             domain="garmin.cn" if is_cn else "garmin.com"
         )

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -157,6 +157,11 @@ class Garmin:
 
         self.garmin_workouts = "/workout-service"
 
+        self.garmin_connect_delete_activity_url = (
+            "/activity-service/activity"
+        )
+
+
         self.garth = garth.Client(
             domain="garmin.cn" if is_cn else "garmin.com"
         )
@@ -805,6 +810,19 @@ class Garmin:
             raise GarminConnectInvalidFileFormatError(
                 f"Could not upload {activity_path}"
             )
+
+    def delete_activity(self, activity_id):
+        """Delete activity with specified id"""
+
+        url = f"{self.garmin_connect_delete_activity_url}/{activity_id}"
+        logger.debug("Deleting activity with id %s", activity_id)
+
+        return self.garth.request(
+            "DELETE",
+            "connectapi",
+            url,
+            api=True,
+        )
 
     def get_activities_by_date(self, startdate, enddate, activitytype=None):
         """


### PR DESCRIPTION
Added one endpoint and renamed another. Also updated .gitignore

- Renamed `get_activity_evaluation` to `get_activity` and updated docstring/logger, because this returns all activity summary, not just the evaluation. Also updated example.py
- Added `delete_activity`, which accepts an activity id, and deletes that activity from Garmin Connect
- Updated the .gitignore file to add `ignore/` and `.idea/`. Adding `ignore/` allows for easy local testing in a confined folder without having to worry about accidentally committing extra files. `.idea/` is an automatically generated PyCharm folder, if you use PyCharm
