### PR TITLE
Adding device solar data endpoint

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -28,6 +28,7 @@ class Garmin:
             "/device-service/deviceregistration/devices"
         )
         self.garmin_connect_device_url = "/device-service/deviceservice"
+        self.garmin_connect_solar_url = "/web-gateway/solar"
         self.garmin_connect_weight_url = "/weight-service"
         self.garmin_connect_daily_summary_url = (
             "/usersummary-service/usersummary/daily"
@@ -728,6 +729,20 @@ class Garmin:
         logger.debug("Requesting device settings")
 
         return self.connectapi(url)
+
+    def get_device_solar_data(self, device_id: str, startdate: str, enddate: str = None) -> Dict[str, Any]:
+        """Return solar data for compatible device with 'device_id'"""
+        if enddate is None:
+            enddate = startdate
+            single_day = True
+        else:
+            single_day = False
+
+        params = {'singleDayView': single_day}
+
+        url = f"{self.garmin_connect_solar_url}/{device_id}/{startdate}/{enddate}"
+
+        return self.connectapi(url, params=params)['deviceSolarInput']
 
     def get_device_alarms(self) -> Dict[str, Any]:
         """Get list of active alarms from all devices."""


### PR DESCRIPTION
Issue https://github.com/cyberjunky/python-garminconnect/issues/190

Adding endpoint for device solar data.

I limited the return values to just the specific solar data `deviceSolarInput` because it's already a lot of data, and I suspect we already return all the other data from the device settings endpoint

If the device has no solar data, it returns the following value (I tested with my non solar 945):

`{'solarDailyDataDTOs': []}`

With solar data, it returns something like the following

```python
    {
      "solarDailyDataDTOs": 
          [ # List with one entry per day
              {
                  "localConnectDate": "2024-03-10",
                  "userProfilePk": 71328280,
                  "deviceId": 3424284515,
                  "solarInputReadings": [
                      {
                          "readingTimestampLocal": "2024-03-10T00:01:00.0",
                          "readingTimestampGmt": "2024-03-10T05:01:00.0",
                          "solarUtilization": 0.0,
                          "notChargingTooHot": false,
                          "notChargingTooCold": false,
                          "notChargingBatteryFull": false,
                          "notChargingExternalPower": false,
                          "notChargingUserDisabled": false,
                          "notChargingOther": true,
                          "activityTimeGainMs": 0,
                          "charging": false,
                          "interpolated": null
                      },             
                        # ... one reading per second? Possibly depends on device                             
                      {
                          "readingTimestampLocal": "2024-03-10T15:55:00.0",
                          "readingTimestampGmt": "2024-03-10T19:55:00.0",
                          "solarUtilization": 0.9900000095367432,
                          "notChargingTooHot": false,
                          "notChargingTooCold": false,
                          "notChargingBatteryFull": false,
                          "notChargingExternalPower": false,
                          "notChargingUserDisabled": false,
                          "notChargingOther": false,
                          "activityTimeGainMs": 34,
                          "charging": true,
                          "interpolated": null
                       }
              ], 
              "totalActivityTimeGainedMs": 429308
        }
        ... # Could be more entries
     ]
}
          
```