### PR TITLE
Adding endpoint for getting primary training device information

### DIFF
--- a/example.py
+++ b/example.py
@@ -560,6 +560,11 @@ def switch(api, i):
                         f"api.get_device_settings({device_id})",
                         api.get_device_settings(device_id),
                     )
+
+                # Get primary training device information
+                device_primary_training_info = api.get_primary_training_device_info()
+                display_json("api.get_primary_training_device_info()", device_primary_training_info)
+
             elif i == "R":
                 # Get solar data from Garmin devices
                 devices = api.get_devices()

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -28,6 +28,9 @@ class Garmin:
             "/device-service/deviceregistration/devices"
         )
         self.garmin_connect_device_url = "/device-service/deviceservice"
+
+        self.garmin_connect_primary_device_url = "/web-gateway/device-info/primary-training-device"
+
         self.garmin_connect_solar_url = "/web-gateway/solar"
         self.garmin_connect_weight_url = "/weight-service"
         self.garmin_connect_daily_summary_url = (
@@ -738,6 +741,16 @@ class Garmin:
 
         url = f"{self.garmin_connect_device_url}/device-info/settings/{device_id}"
         logger.debug("Requesting device settings")
+
+        return self.connectapi(url)
+
+    def get_primary_training_device_info(self) -> Dict[str, Any]:
+        """Return detailed information around primary training devices, included the specified device and the
+        priority of all devices.
+        """
+
+        url = self.garmin_connect_primary_device_url
+        logger.debug("Requesting primary training device information")
 
         return self.connectapi(url)
 


### PR DESCRIPTION
Returns primary training device info, as well as a list of all devices.  We could adjust it slightly if we wanted to minimize the return data to just Primary Training Device info, but I'm not sure if that's necessary.

That would look like...

```python
...
response = self.connectapi(url)
del response['RegisteredDevices']
return response 
```


Return data looks like:

```python
{'PrimaryTrainingDevice': {'deviceId': XXX},
 'WearableDevices': {'deviceWeights': [{'displayName': 'Forerunner 955 Solar',
    'deviceId': XXX,
    'imageUrl': 'https://s3.amazonaws.com/garmin-connect-prod/profile_images/98d07f81-3a9f-4d5a-9172-45c6c3080d36-71.png',
    'weight': 3,
    'primaryTrainingCapable': True,
    'lhaBackupCapable': True,
    'primaryWearableDevice': True},
   {'displayName': 'Forerunner 945',
    'deviceId': XXX,
    'imageUrl': 'https://static.garmincdn.com/com.garmin.connect/content/images/device-images/forerunner-945.png',
    'weight': 1,
    'primaryTrainingCapable': False,
    'lhaBackupCapable': False,
    'trainingStatusCapable': True}],
  'wearableDeviceCount': 2},
 'TrainingStatusOnlyDevices': {'deviceWeights': [{'displayName': 'Forerunner 945',
    'deviceId': XXX,
    'imageUrl': 'https://static.garmincdn.com/com.garmin.connect/content/images/device-images/forerunner-945.png',
    'weight': 1,
    'primaryTrainingCapable': False,
    'lhaBackupCapable': False,
    'trainingStatusCapable': True}]},
 'PrimaryTrainingDevices': {'deviceWeights': [{'displayName': 'Forerunner 955 Solar',
    'deviceId': XXX,
    'imageUrl': 'https://s3.amazonaws.com/garmin-connect-prod/profile_images/98d07f81-3a9f-4d5a-9172-45c6c3080d36-71.png',
    'weight': 3,
    'primaryTrainingCapable': True,
    'lhaBackupCapable': True,
    'primaryWearableDevice': True}],
  'primaryTrainingDeviceCount': 1},
'RegisteredDevices': [
   ...list of devices as in get_devices() return
]
}
```