### PR TITLE
Bugfix Issue #196

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -347,8 +347,8 @@ class Garmin:
         # Apply timezone offset to get UTC/GMT time
         dtGMT = dt.astimezone(timezone.utc)
         payload = {
-            "measurementTimestampLocal": dt.isoformat()[:19] + ".00",
-            "measurementTimestampGMT": dtGMT.isoformat()[:19] + ".00",
+            "dateTimestamp": dt.isoformat()[:19] + ".00",
+            "gmtTimestamp": dtGMT.isoformat()[:19] + ".00",
             "unitKey": unitKey,
             "sourceType": "MANUAL",
             "value": weight,


### PR DESCRIPTION
[Issue 196](https://github.com/cyberjunky/python-garminconnect/issues/196).  Looks like the names of the timestamps in the add weigh in payload changed. 

It's possible there are other areas this might need to be changed to.

I get a 400 with the original names, but a 204 now