### PR TITLE
Add endpoint for adding hydration data

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ O -- Reload epoch data for 2024-03-15
 P -- Get workouts 0-100, get and download last one to .FIT file
 R -- Get solar data from your devices
 S -- Get pregnancy summary data
+T -- Add hydration data (1 cup) for today
 Z -- Remove stored login tokens (logout)
 q -- Exit
 Make your selection: 

--- a/example.py
+++ b/example.py
@@ -824,7 +824,7 @@ def switch(api, i):
                 timestamp = datetime.datetime.strftime(raw_ts, '%Y-%m-%dT%H:%M:%S.%f')
 
                 display_json(
-                    f"api.add_hydration_data(value_in_ml={value_in_ml},cdate={cdate},timestamp={timestamp})",
+                    f"api.add_hydration_data(value_in_ml={value_in_ml},cdate='{cdate}',timestamp='{timestamp}')",
                     api.add_hydration_data(value_in_ml=value_in_ml,
                                            cdate=cdate,
                                            timestamp=timestamp)

--- a/example.py
+++ b/example.py
@@ -134,6 +134,7 @@ menu_options = {
     # "Q": "Upload workout from json data",
     "R": "Get solar data from your devices",
     "S": "Get pregnancy summary data",
+    "T": "Add hydration data",
     "Z": "Remove stored login tokens (logout)",
     "q": "Exit",
 }
@@ -813,6 +814,21 @@ def switch(api, i):
             # Additional related calls:
             # get_menstrual_data_for_date(self, fordate: str): takes a single date and returns the Garmin Menstrual Summary data for that date
             # get_menstrual_calendar_data(self, startdate: str, enddate: str) takes two dates and returns summaries of cycles that have days between the two days
+
+            elif i == "T":
+                # Add hydration data for today
+                value_in_ml = 240
+                raw_date = datetime.date.today()
+                cdate = str(raw_date)
+                raw_ts = datetime.datetime.now()
+                timestamp = datetime.datetime.strftime(raw_ts, '%Y-%m-%dT%H:%M:%S.%f')
+
+                display_json(
+                    f"api.add_hydration_data(value_in_ml={value_in_ml},cdate={cdate},timestamp={timestamp})",
+                    api.add_hydration_data(value_in_ml=value_in_ml,
+                                           cdate=cdate,
+                                           timestamp=timestamp)
+                )
 
             elif i == "Z":
                 # Remove stored login tokens for Garmin Connect portal

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -503,13 +503,23 @@ class Garmin:
 
         url = self.garmin_connect_set_hydration_url
 
-        if cdate is None:
+        if timestamp is None and cdate is None:
+            # If both are null, use today and now
             raw_date = date.today()
             cdate = str(raw_date)
 
-        if timestamp is None:
             raw_ts = datetime.now()
             timestamp = datetime.strftime(raw_ts, '%Y-%m-%dT%H:%M:%S.%f')
+
+        elif cdate is not None and timestamp is None:
+            # If cdate is not null, use timestamp associated with midnight
+            raw_ts = datetime.strptime(cdate, '%Y-%m-%d')
+            timestamp = datetime.strftime(raw_ts, '%Y-%m-%dT%H:%M:%S.%f')
+
+        elif cdate is None and timestamp is not None:
+            # If timestamp is not null, set cdate equal to date part of timestamp
+            raw_ts = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+            cdate = str(raw_ts.date())
 
         payload = {
             "calendarDate": cdate,

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional
 
@@ -46,6 +46,9 @@ class Garmin:
         )
         self.garmin_connect_daily_hydration_url = (
             "/usersummary-service/usersummary/hydration/daily"
+        )
+        self.garmin_connect_set_hydration_url =  (
+            "usersummary-service/usersummary/hydration/log"
         )
         self.garmin_connect_daily_stats_steps_url = (
             "/usersummary-service/stats/steps/daily"
@@ -490,6 +493,33 @@ class Garmin:
         logger.debug("Requesting max metrics")
 
         return self.connectapi(url)
+
+    def add_hydration_data(self, value_in_ml: float, timestamp=None, cdate: str=None) -> Dict[str, Any]:
+        """Add hydration data in ml.  Defaults to current date and current timestamp if left empty
+        :param float required - value_in_ml: The number of ml of water you wish to add (positive) or subtract (negative)
+        :param timestamp optional - timestamp: The timestamp of the hydration update, format 'YYYY-MM-DDThh:mm:ss.ms' Defaults to current timestamp
+        :param date optional - cdate: The date of the weigh in, format 'YYYY-MM-DD'. Defaults to current date
+        """
+
+        url = self.garmin_connect_set_hydration_url
+
+        if cdate is None:
+            raw_date = date.today()
+            cdate = str(raw_date)
+
+        if timestamp is None:
+            raw_ts = datetime.now()
+            timestamp = datetime.strftime(raw_ts, '%Y-%m-%dT%H:%M:%S.%f')
+
+        payload = {
+            "calendarDate": cdate,
+            "timestampLocal": timestamp,
+            "valueInML": value_in_ml
+            }
+
+        logger.debug("Adding hydration data")
+
+        return self.garth.put('connectapi', url, json=payload)
 
     def get_hydration_data(self, cdate: str) -> Dict[str, Any]:
         """Return available hydration data 'cdate' format 'YYYY-MM-DD'."""


### PR DESCRIPTION
Asked for in https://github.com/cyberjunky/python-garminconnect/issues/204

Added to example.py and readme as well

Tested on my own and works with both dates, no dates, only cdate, and only timestamp.

It doesn't appear that the dates are actually used for anything in Garmin connect, but maybe they will be eventually.

This endpoint does not require that the date and timestamp be on the same day