### PR TITLE
Extend API to retrieve fitness age data

### DIFF
--- a/example.py
+++ b/example.py
@@ -135,6 +135,7 @@ menu_options = {
     "R": "Get solar data from your devices",
     "S": "Get pregnancy summary data",
     "T": "Add hydration data",
+    "U": f"Get Fitness Age data for {today.isoformat()}",
     "Z": "Remove stored login tokens (logout)",
     "q": "Exit",
 }
@@ -828,6 +829,13 @@ def switch(api, i):
                     api.add_hydration_data(value_in_ml=value_in_ml,
                                            cdate=cdate,
                                            timestamp=timestamp)
+                )
+
+            elif i == "U":
+                # Get fitness age data
+                display_json(
+                    f"api.get_fitnessage_data({today.isoformat()})",
+                    api.get_fitnessage_data(today.isoformat())
                 )
 
             elif i == "Z":

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -152,6 +152,7 @@ class Garmin:
             "/mobile-gateway/heartRate/forDate"
         )
         self.garmin_connect_fitnessstats = "/fitnessstats-service/activity"
+        self.garmin_connect_fitnessage = "/fitnessage-service/fitnessage"
 
         self.garmin_connect_fit_download = "/download-service/files/activity"
         self.garmin_connect_tcx_download = (
@@ -751,6 +752,14 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def get_fitnessage_data(self, cdate: str) -> Dict[str, Any]:
+        """Return Fitness Age data for current user."""
+
+        url = f"{self.garmin_connect_fitnessage}/{cdate}"
+        logger.debug("Requesting Fitness Age data")
+
+        return self.connectapi(url)
+    
     def get_hill_score(self, startdate: str, enddate=None):
         """
         Return hill score by day from 'startdate' format 'YYYY-MM-DD'


### PR DESCRIPTION
Retrieves the following stats (fake values) from `https://connect.garmin.com/fitnessage-service/fitnessage/[date]`:
```
{
    "chronologicalAge": 20,
    "fitnessAge": 18.315871748264364,
    "achievableFitnessAge": 19.38654477840031,
    "previousFitnessAge": 18.315871748264364,
    "components": {
        "vigorousDaysAvg": {
            "value": 2.5,
            "stale": false,
            "numOfWeeksForIm": 4
        },
        "rhr": {
            "value": 52,
            "stale": false
        },
        "vigorousMinutesAvg": {
            "value": 104.5,
            "stale": false,
            "numOfWeeksForIm": 4
        },
        "bmi": {
            "value": 20.0,
            "stale": false,
            "lastMeasurementDate": "2024-06-19"
        }
    },
    "lastUpdated": "2024-06-22T00:00:00.0"
}
```