### PR TITLE
Adding new endpoint for additional split information

### DIFF
--- a/example.py
+++ b/example.py
@@ -499,6 +499,12 @@ def switch(api, i):
                     api.get_activity_splits(first_activity_id),
                 )
 
+                # Get activity typed splits
+
+                display_json(
+                    f"api.get_activity_typed_splits({first_activity_id})",
+                    api.get_activity_typed_splits(first_activity_id),
+                )
                 # Get activity split summaries for activity id
                 display_json(
                     f"api.get_activity_split_summaries({first_activity_id})",

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1104,6 +1104,16 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def get_activity_typed_splits(self, activity_id):
+        """Return typed activity splits. Contains similar info to `get_activity_splits`, but for certain activity types
+        (e.g., Bouldering), this contains more detail."""
+
+        activity_id = str(activity_id)
+        url = f"{self.garmin_connect_activity}/{activity_id}/typedsplits"
+        logger.debug("Requesting typed splits for activity id %s", activity_id)
+
+        return self.connectapi(url)
+
     def get_activity_split_summaries(self, activity_id):
         """Return activity split summaries."""
 


### PR DESCRIPTION
#214 Adding get_activity_typed_splits which contains more split info

These two split endpoints (`/splits` and `/typedsplits`) contain slightly different info, which is annoying