### PR TITLE
Daily Events Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ R -- Get solar data from your devices
 S -- Get pregnancy summary data
 T -- Add hydration data
 U -- Get Fitness Age data for 2024-07-06
+V -- Get daily wellness events for 2024-07-06
 Z -- Remove stored login tokens (logout)
 q -- Exit
 Make your selection:

--- a/example.py
+++ b/example.py
@@ -499,6 +499,12 @@ def switch(api, i):
                     api.get_activity_splits(first_activity_id),
                 )
 
+                # Get activity typed splits
+
+                display_json(
+                    f"api.get_activity_typed_splits({first_activity_id})",
+                    api.get_activity_typed_splits(first_activity_id),
+                )
                 # Get activity split summaries for activity id
                 display_json(
                     f"api.get_activity_split_summaries({first_activity_id})",

--- a/example.py
+++ b/example.py
@@ -808,7 +808,6 @@ def switch(api, i):
                 output_file = f"./{str(workout_name)}.fit"
                 with open(output_file, "wb") as fb:
                     fb.write(workout_data)
-
                 print(f"Workout data downloaded to file {output_file}")
 
             # elif i == "Q":
@@ -861,7 +860,6 @@ def switch(api, i):
                 # Remove stored login tokens for Garmin Connect portal
                 tokendir = os.path.expanduser(tokenstore)
                 print(f"Removing stored login tokens from: {tokendir}")
-
                 try:
                     for root, dirs, files in os.walk(tokendir, topdown=False):
                         for name in files:

--- a/example.py
+++ b/example.py
@@ -136,6 +136,7 @@ menu_options = {
     "S": "Get pregnancy summary data",
     "T": "Add hydration data",
     "U": f"Get Fitness Age data for {today.isoformat()}",
+    "V": f"Get daily wellness events data for {startdate.isoformat()}",
     "Z": "Remove stored login tokens (logout)",
     "q": "Exit",
 }
@@ -322,6 +323,11 @@ def switch(api, i):
                 display_json(
                     f"api.get_body_battery('{startdate.isoformat()}, {today.isoformat()}')",
                     api.get_body_battery(startdate.isoformat(), today.isoformat()),
+                )
+                # Get daily body battery event data for 'YYYY-MM-DD'
+                display_json(
+                    f"api.get_body_battery_events('{startdate.isoformat()}, {today.isoformat()}')",
+                    api.get_body_battery_events(startdate.isoformat()),
                 )
             elif i == "?":
                 # Get daily blood pressure data for 'YYYY-MM-DD' to 'YYYY-MM-DD'
@@ -798,7 +804,7 @@ def switch(api, i):
                 workout_data = api.download_workout(
                     workout_id
                 )
-                
+
                 output_file = f"./{str(workout_name)}.fit"
                 with open(output_file, "wb") as fb:
                     fb.write(workout_data)
@@ -810,6 +816,13 @@ def switch(api, i):
             #         f"api.upload_workout({workout_example})",
             #         api.upload_workout(workout_example))
 
+            # DAILY EVENTS
+            elif i == "V":
+                # Get all day wellness events for 7 days ago
+                display_json(
+                     f"api.get_all_day_events({startdate.isoformat()})",
+                     api.get_all_day_events(startdate.isoformat())
+                             )
             # WOMEN'S HEALTH
             elif i == "S":
                 # Get pregnancy summary data
@@ -848,7 +861,7 @@ def switch(api, i):
                 # Remove stored login tokens for Garmin Connect portal
                 tokendir = os.path.expanduser(tokenstore)
                 print(f"Removing stored login tokens from: {tokendir}")
-                
+
                 try:
                     for root, dirs, files in os.walk(tokendir, topdown=False):
                         for name in files:

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -16,7 +16,7 @@ class Garmin:
     """Class for fetching data from Garmin Connect."""
 
     def __init__(
-        self, email=None, password=None, is_cn=False, prompt_mfa=None
+            self, email=None, password=None, is_cn=False, prompt_mfa=None
     ):
         """Create a new class instance."""
         self.username = email
@@ -84,6 +84,10 @@ class Garmin:
 
         self.garmin_connect_daily_body_battery_url = (
             "/wellness-service/wellness/bodyBattery/reports/daily"
+        )
+
+        self.garmin_connect_body_battery_events_url = (
+            "/wellness-service/wellness/bodyBattery/events"
         )
 
         self.garmin_connect_blood_pressure_endpoint = (
@@ -295,7 +299,7 @@ class Garmin:
         }
 
     def get_body_composition(
-        self, startdate: str, enddate=None
+            self, startdate: str, enddate=None
     ) -> Dict[str, Any]:
         """
         Return available body composition data for 'startdate' format
@@ -311,20 +315,20 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def add_body_composition(
-        self,
-        timestamp: Optional[str],
-        weight: float,
-        percent_fat: Optional[float] = None,
-        percent_hydration: Optional[float] = None,
-        visceral_fat_mass: Optional[float] = None,
-        bone_mass: Optional[float] = None,
-        muscle_mass: Optional[float] = None,
-        basal_met: Optional[float] = None,
-        active_met: Optional[float] = None,
-        physique_rating: Optional[float] = None,
-        metabolic_age: Optional[float] = None,
-        visceral_fat_rating: Optional[float] = None,
-        bmi: Optional[float] = None,
+            self,
+            timestamp: Optional[str],
+            weight: float,
+            percent_fat: Optional[float] = None,
+            percent_hydration: Optional[float] = None,
+            visceral_fat_mass: Optional[float] = None,
+            bone_mass: Optional[float] = None,
+            muscle_mass: Optional[float] = None,
+            basal_met: Optional[float] = None,
+            active_met: Optional[float] = None,
+            physique_rating: Optional[float] = None,
+            metabolic_age: Optional[float] = None,
+            visceral_fat_rating: Optional[float] = None,
+            bmi: Optional[float] = None,
     ):
         dt = datetime.fromisoformat(timestamp) if timestamp else datetime.now()
         fitEncoder = fit.FitEncoderWeight()
@@ -355,7 +359,7 @@ class Garmin:
         return self.garth.post("connectapi", url, files=files, api=True)
 
     def add_weigh_in(
-        self, weight: int, unitKey: str = "kg", timestamp: str = ""
+            self, weight: int, unitKey: str = "kg", timestamp: str = ""
     ):
         """Add a weigh-in (default to kg)"""
 
@@ -429,7 +433,7 @@ class Garmin:
         return len(weigh_ins)
 
     def get_body_battery(
-        self, startdate: str, enddate=None
+            self, startdate: str, enddate=None
     ) -> List[Dict[str, Any]]:
         """
         Return body battery values by day for 'startdate' format
@@ -444,13 +448,25 @@ class Garmin:
 
         return self.connectapi(url, params=params)
 
+    def get_body_battery_events(self, cdate: str) -> List[Dict[str, Any]]:
+        """
+        Return body battery events for date 'cdate' format 'YYYY-MM-DD'.
+        The return value is a list of dictionaries, where each dictionary contains event data for a specific event.
+        Events can include sleep, recorded activities, auto-detected activities, and naps
+        """
+
+        url = f"{self.garmin_connect_body_battery_events_url}/{cdate}"
+        logger.debug("Requesting body battery event data")
+
+        return self.connectapi(url)
+
     def set_blood_pressure(
-        self,
-        systolic: int,
-        diastolic: int,
-        pulse: int,
-        timestamp: str = "",
-        notes: str = "",
+            self,
+            systolic: int,
+            diastolic: int,
+            pulse: int,
+            timestamp: str = "",
+            notes: str = "",
     ):
         """
         Add blood pressure measurement
@@ -475,7 +491,7 @@ class Garmin:
         return self.garth.post("connectapi", url, json=payload)
 
     def get_blood_pressure(
-        self, startdate: str, enddate=None
+            self, startdate: str, enddate=None
     ) -> Dict[str, Any]:
         """
         Returns blood pressure by day for 'startdate' format
@@ -499,7 +515,7 @@ class Garmin:
         return self.connectapi(url)
 
     def add_hydration_data(
-        self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None
+            self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None
     ) -> Dict[str, Any]:
         """Add hydration data in ml.  Defaults to current date and current timestamp if left empty
         :param float required - value_in_ml: The number of ml of water you wish to add (positive) or subtract (negative)
@@ -572,7 +588,7 @@ class Garmin:
     def get_all_day_events(self, cdate: str) -> Dict[str, Any]:
         """
         Return available daily events data 'cdate' format 'YYYY-MM-DD'.
-        Includes naps and autodetected activities, even if not recorded on the watch
+        Includes autodetected activities, even if not recorded on the watch
         """
 
         url = f"{self.garmin_daily_events_url}?calendarDate={cdate}"
@@ -624,7 +640,7 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_non_completed_badge_challenges(
-        self, start, limit
+            self, start, limit
     ) -> Dict[str, Any]:
         """Return badge non-completed challenges for current user."""
 
@@ -635,7 +651,7 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_inprogress_virtual_challenges(
-        self, start, limit
+            self, start, limit
     ) -> Dict[str, Any]:
         """Return in-progress virtual challenges for current user."""
 
@@ -737,17 +753,17 @@ class Garmin:
 
         if _type is None and startdate is None and enddate is None:
             url = (
-                self.garmin_connect_race_predictor_url
-                + f"/latest/{self.display_name}"
+                    self.garmin_connect_race_predictor_url
+                    + f"/latest/{self.display_name}"
             )
             return self.connectapi(url)
 
         elif (
-            _type is not None and startdate is not None and enddate is not None
+                _type is not None and startdate is not None and enddate is not None
         ):
             url = (
-                self.garmin_connect_race_predictor_url
-                + f"/{_type}/{self.display_name}"
+                    self.garmin_connect_race_predictor_url
+                    + f"/{_type}/{self.display_name}"
             )
             params = {
                 "fromCalendarDate": str(startdate),
@@ -827,7 +843,7 @@ class Garmin:
         return self.connectapi(url)
 
     def get_device_solar_data(
-        self, device_id: str, startdate: str, enddate=None
+            self, device_id: str, startdate: str, enddate=None
     ) -> Dict[str, Any]:
         """Return solar data for compatible device with 'device_id'"""
         if enddate is None:
@@ -905,7 +921,7 @@ class Garmin:
         file_base_name = os.path.basename(activity_path)
         file_extension = file_base_name.split(".")[-1]
         allowed_file_extension = (
-            file_extension.upper() in Garmin.ActivityUploadFormat.__members__
+                file_extension.upper() in Garmin.ActivityUploadFormat.__members__
         )
 
         if allowed_file_extension:
@@ -964,7 +980,7 @@ class Garmin:
         )
         while True:
             params["start"] = str(start)
-            logger.debug(f"Requesting activities {start} to {start+limit}")
+            logger.debug(f"Requesting activities {start} to {start + limit}")
             act = self.connectapi(url, params=params)
             if act:
                 activities.extend(act)
@@ -975,7 +991,7 @@ class Garmin:
         return activities
 
     def get_progress_summary_between_dates(
-        self, startdate, enddate, metric="distance", groupbyactivities=True
+            self, startdate, enddate, metric="distance", groupbyactivities=True
     ):
         """
         Fetch progress summary data between specific dates
@@ -1086,7 +1102,7 @@ class Garmin:
         TCX = auto()
 
     def download_activity(
-        self, activity_id, dl_fmt=ActivityDownloadFormat.TCX
+            self, activity_id, dl_fmt=ActivityDownloadFormat.TCX
     ):
         """
         Downloads activity in requested format and returns the raw bytes. For

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -141,6 +141,9 @@ class Garmin:
         self.garmin_all_day_stress_url = (
             "/wellness-service/wellness/dailyStress"
         )
+        self.garmin_daily_events_url = (
+            "/wellness-service/wellness/dailyEvents"
+        )
         self.garmin_connect_activities = (
             "/activitylist-service/activities/search/activities"
         )
@@ -562,6 +565,17 @@ class Garmin:
         """Return available all day stress data 'cdate' format 'YYYY-MM-DD'."""
 
         url = f"{self.garmin_all_day_stress_url}/{cdate}"
+        logger.debug("Requesting all day stress data")
+
+        return self.connectapi(url)
+
+    def get_all_day_events(self, cdate: str) -> Dict[str, Any]:
+        """
+        Return available daily events data 'cdate' format 'YYYY-MM-DD'.
+        Includes naps and autodetected activities, even if not recorded on the watch
+        """
+
+        url = f"{self.garmin_daily_events_url}?calendarDate={cdate}"
         logger.debug("Requesting all day stress data")
 
         return self.connectapi(url)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -16,7 +16,7 @@ class Garmin:
     """Class for fetching data from Garmin Connect."""
 
     def __init__(
-            self, email=None, password=None, is_cn=False, prompt_mfa=None
+        self, email=None, password=None, is_cn=False, prompt_mfa=None
     ):
         """Create a new class instance."""
         self.username = email
@@ -299,7 +299,7 @@ class Garmin:
         }
 
     def get_body_composition(
-            self, startdate: str, enddate=None
+        self, startdate: str, enddate=None
     ) -> Dict[str, Any]:
         """
         Return available body composition data for 'startdate' format
@@ -315,20 +315,20 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def add_body_composition(
-            self,
-            timestamp: Optional[str],
-            weight: float,
-            percent_fat: Optional[float] = None,
-            percent_hydration: Optional[float] = None,
-            visceral_fat_mass: Optional[float] = None,
-            bone_mass: Optional[float] = None,
-            muscle_mass: Optional[float] = None,
-            basal_met: Optional[float] = None,
-            active_met: Optional[float] = None,
-            physique_rating: Optional[float] = None,
-            metabolic_age: Optional[float] = None,
-            visceral_fat_rating: Optional[float] = None,
-            bmi: Optional[float] = None,
+        self,
+        timestamp: Optional[str],
+        weight: float,
+        percent_fat: Optional[float] = None,
+        percent_hydration: Optional[float] = None,
+        visceral_fat_mass: Optional[float] = None,
+        bone_mass: Optional[float] = None,
+        muscle_mass: Optional[float] = None,
+        basal_met: Optional[float] = None,
+        active_met: Optional[float] = None,
+        physique_rating: Optional[float] = None,
+        metabolic_age: Optional[float] = None,
+        visceral_fat_rating: Optional[float] = None,
+        bmi: Optional[float] = None,
     ):
         dt = datetime.fromisoformat(timestamp) if timestamp else datetime.now()
         fitEncoder = fit.FitEncoderWeight()
@@ -359,7 +359,7 @@ class Garmin:
         return self.garth.post("connectapi", url, files=files, api=True)
 
     def add_weigh_in(
-            self, weight: int, unitKey: str = "kg", timestamp: str = ""
+        self, weight: int, unitKey: str = "kg", timestamp: str = ""
     ):
         """Add a weigh-in (default to kg)"""
 
@@ -433,7 +433,7 @@ class Garmin:
         return len(weigh_ins)
 
     def get_body_battery(
-            self, startdate: str, enddate=None
+        self, startdate: str, enddate=None
     ) -> List[Dict[str, Any]]:
         """
         Return body battery values by day for 'startdate' format
@@ -461,12 +461,12 @@ class Garmin:
         return self.connectapi(url)
 
     def set_blood_pressure(
-            self,
-            systolic: int,
-            diastolic: int,
-            pulse: int,
-            timestamp: str = "",
-            notes: str = "",
+        self,
+        systolic: int,
+        diastolic: int,
+        pulse: int,
+        timestamp: str = "",
+        notes: str = "",
     ):
         """
         Add blood pressure measurement
@@ -515,7 +515,7 @@ class Garmin:
         return self.connectapi(url)
 
     def add_hydration_data(
-            self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None
+        self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None
     ) -> Dict[str, Any]:
         """Add hydration data in ml.  Defaults to current date and current timestamp if left empty
         :param float required - value_in_ml: The number of ml of water you wish to add (positive) or subtract (negative)
@@ -640,7 +640,7 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_non_completed_badge_challenges(
-            self, start, limit
+        self, start, limit
     ) -> Dict[str, Any]:
         """Return badge non-completed challenges for current user."""
 
@@ -651,7 +651,7 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_inprogress_virtual_challenges(
-            self, start, limit
+        self, start, limit
     ) -> Dict[str, Any]:
         """Return in-progress virtual challenges for current user."""
 
@@ -753,17 +753,17 @@ class Garmin:
 
         if _type is None and startdate is None and enddate is None:
             url = (
-                    self.garmin_connect_race_predictor_url
-                    + f"/latest/{self.display_name}"
+                self.garmin_connect_race_predictor_url
+                + f"/latest/{self.display_name}"
             )
             return self.connectapi(url)
 
         elif (
-                _type is not None and startdate is not None and enddate is not None
+            _type is not None and startdate is not None and enddate is not None
         ):
             url = (
-                    self.garmin_connect_race_predictor_url
-                    + f"/{_type}/{self.display_name}"
+                self.garmin_connect_race_predictor_url
+                + f"/{_type}/{self.display_name}"
             )
             params = {
                 "fromCalendarDate": str(startdate),
@@ -843,7 +843,7 @@ class Garmin:
         return self.connectapi(url)
 
     def get_device_solar_data(
-            self, device_id: str, startdate: str, enddate=None
+        self, device_id: str, startdate: str, enddate=None
     ) -> Dict[str, Any]:
         """Return solar data for compatible device with 'device_id'"""
         if enddate is None:
@@ -921,7 +921,7 @@ class Garmin:
         file_base_name = os.path.basename(activity_path)
         file_extension = file_base_name.split(".")[-1]
         allowed_file_extension = (
-                file_extension.upper() in Garmin.ActivityUploadFormat.__members__
+            file_extension.upper() in Garmin.ActivityUploadFormat.__members__
         )
 
         if allowed_file_extension:
@@ -980,7 +980,7 @@ class Garmin:
         )
         while True:
             params["start"] = str(start)
-            logger.debug(f"Requesting activities {start} to {start + limit}")
+            logger.debug(f"Requesting activities {start} to {start+limit}")
             act = self.connectapi(url, params=params)
             if act:
                 activities.extend(act)
@@ -991,7 +991,7 @@ class Garmin:
         return activities
 
     def get_progress_summary_between_dates(
-            self, startdate, enddate, metric="distance", groupbyactivities=True
+        self, startdate, enddate, metric="distance", groupbyactivities=True
     ):
         """
         Fetch progress summary data between specific dates
@@ -1102,7 +1102,7 @@ class Garmin:
         TCX = auto()
 
     def download_activity(
-            self, activity_id, dl_fmt=ActivityDownloadFormat.TCX
+        self, activity_id, dl_fmt=ActivityDownloadFormat.TCX
     ):
         """
         Downloads activity in requested format and returns the raw bytes. For

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1104,6 +1104,16 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def get_activity_typed_splits(self, activity_id):
+        """Return typed activity splits. Contains similar info to `get_activity_splits`, but for certain activity types
+        (e.g., Bouldering), this contains more detail."""
+
+        activity_id = str(activity_id)
+        url = f"{self.garmin_connect_activity}/{activity_id}/typedsplits"
+        logger.debug("Requesting typed splits for activity id %s", activity_id)
+
+        return self.connectapi(url)
+
     def get_activity_split_summaries(self, activity_id):
         """Return activity split summaries."""
 


### PR DESCRIPTION
Adds two endpoints.

First, a body battery daily events endpoint, which includes:
- Naps
- Autodetected activities like walks
- All activities (in a summary form)

For each of these, it includes the body battery impact information

I believe this endpoint is used to populate the Body Battery graph 

Second, a wellness daily events endpoint, which includes highly summarized info for all recorded and auto-detected activities