### PR TITLE
Add project.optional-dependecies to allow install via pip and add example dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ linting = [
     "isort",
     "types-requests",
 ]
-"testing" = [
+testing = [
     "coverage",
     "pytest",
     "pytest-vcr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,30 @@ use_parentheses = true
 line_length = 79
 known_first_party = "garminconnect"
 
+[project.optional-dependencies]
+dev = [
+    "ipython",
+    "ipdb",
+    "ipykernel",
+    "pandas",
+    "matplotlib",
+]
+linting = [
+    "black",
+    "ruff",
+    "mypy",
+    "isort",
+    "types-requests",
+]
+"testing" = [
+    "coverage",
+    "pytest",
+    "pytest-vcr",
+]
+example = [
+    "readchar",
+]
+
 [tool.pdm]
 distribution = true
 [tool.pdm.dev-dependencies]
@@ -63,4 +87,7 @@ testing = [
     "coverage",
     "pytest",
     "pytest-vcr",
+]
+example = [
+    "readchar",
 ]


### PR DESCRIPTION
This enables the install of optional dependencies via `pip install -e ".[dev]". Also adds a dependency group for the example script where readchar is the only missing dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined approach for optional dependencies, letting users select tailored groups for development, code quality, testing, and example usage to enhance setup and workflow customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->