### PR TITLE
Revert "#253 - Updating Max Metrics URL"

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -46,7 +46,7 @@ class Garmin:
             "/usersummary-service/usersummary/daily"
         )
         self.garmin_connect_metrics_url = (
-            "/metrics-service/metrics/maxmet/latest"
+            "/metrics-service/metrics/maxmet/daily"
         )
         self.garmin_connect_daily_hydration_url = (
             "/usersummary-service/usersummary/hydration/daily"
@@ -601,7 +601,7 @@ class Garmin:
     def get_max_metrics(self, cdate: str) -> Dict[str, Any]:
         """Return available max metric data for 'cdate' format 'YYYY-MM-DD'."""
 
-        url = f"{self.garmin_connect_metrics_url}/{cdate}"
+        url = f"{self.garmin_connect_metrics_url}/{cdate}/{cdate}"
         logger.debug("Requesting max metrics")
 
         return self.connectapi(url)


### PR DESCRIPTION
This reverts commit 663bdd7545b680b58994b91fcf043efd459a263a.
I identified the issue incorrectly and we should revert my change.


The root cause of #253 appears to be that Garmin simply doesn't have Max Metrics for that day yet. I believe until you've done an activity on that day, there are no Max Metrics values

The code as it currently stands only returns the current day, regardless of the date entered