### PR TITLE
Add Lactate Threshold endpoints

### DIFF
--- a/example.py
+++ b/example.py
@@ -915,7 +915,7 @@ def switch(api, i):
                 display_json(
                     "api.get_lactate_threshold(latest=True)", api.get_lactate_threshold(latest=True)
                 )
-                # Get latest lactate threshold
+                # Get historical lactate threshold for past four weeks
                 display_json(f"api.get_lactate_threshold(latest=False, start_date='{startdate_four_weeks.isoformat()}', end_date='{today.isoformat()}', aggregation='daily')", api.get_lactate_threshold(latest=False, start_date=startdate_four_weeks.isoformat(),
                                               end_date=today.isoformat(), aggregation="daily"),                )
             elif i == "Z":

--- a/example.py
+++ b/example.py
@@ -916,9 +916,8 @@ def switch(api, i):
                     "api.get_lactate_threshold(latest=True)", api.get_lactate_threshold(latest=True)
                 )
                 # Get latest lactate threshold
-                display_json(
-                    f"api.get_lactate_threshold(latest=False, start_date='{startdate_four_weeks.isoformat()}, end_date={today}', aggregation='daily')", api.get_lactate_threshold(latest=False, start_date=startdate_four_weeks, end_date=today, aggregation="daily")
-                )
+                display_json(f"api.get_lactate_threshold(latest=False, start_date='{startdate_four_weeks.isoformat()}', end_date='{today.isoformat()}', aggregation='daily')", api.get_lactate_threshold(latest=False, start_date=startdate_four_weeks.isoformat(),
+                                              end_date=today.isoformat(), aggregation="daily"),                )
             elif i == "Z":
                 # Remove stored login tokens for Garmin Connect portal
                 tokendir = os.path.expanduser(tokenstore)

--- a/example.py
+++ b/example.py
@@ -42,6 +42,7 @@ api = None
 # Let's say we want to scrape all activities using switch menu_option "p". We change the values of the below variables, IE startdate days, limit,...
 today = datetime.date.today()
 startdate = today - datetime.timedelta(days=7)  # Select past week
+startdate_four_weeks = today - datetime.timedelta(days=28)
 start = 0
 limit = 100
 start_badge = 1  # Badge related calls calls start counting at 1
@@ -141,6 +142,7 @@ menu_options = {
     "U": f"Get Fitness Age data for {today.isoformat()}",
     "V": f"Get daily wellness events data for {startdate.isoformat()}",
     "W": "Get userprofile settings",
+    "X": "Get lactate threshold data, both Latest and for the past four weeks",
     "Z": "Remove stored login tokens (logout)",
     "q": "Exit",
 }
@@ -908,6 +910,15 @@ def switch(api, i):
                     "api.get_userprofile_settings()", api.get_userprofile_settings()
                 )
 
+            elif i == "X":
+                # Get latest lactate threshold
+                display_json(
+                    "api.get_lactate_threshold(latest=True)", api.get_lactate_threshold(latest=True)
+                )
+                # Get latest lactate threshold
+                display_json(
+                    f"api.get_lactate_threshold(latest=False, start_date='{startdate_four_weeks.isoformat()}, end_date={today}', aggregation='daily')", api.get_lactate_threshold(latest=False, start_date=startdate_four_weeks, end_date=today, aggregation="daily")
+                )
             elif i == "Z":
                 # Remove stored login tokens for Garmin Connect portal
                 tokendir = os.path.expanduser(tokenstore)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -625,7 +625,7 @@ class Garmin:
 
         return self.connectapi(url)
 
-    def get_lactate_threshold(self, latest=True, start_date=None, end_date=None, aggregation="daily") -> Dict:
+    def get_lactate_threshold(self, *,latest: bool=True, start_date: Optional[str|date]=None, end_date: Optional[str|date]=None, aggregation: str ="daily") -> Dict:
         """
         Returns Running Lactate Threshold information, including heart rate, power, and speed
 
@@ -665,7 +665,7 @@ class Garmin:
             # We're combining them here
             for entry in speed_and_heart_rate:
                 if entry['speed'] is not None:
-                    speed_and_heart_rate_dict["userProfilePK"] =entry["userProfilePK"]
+                    speed_and_heart_rate_dict["userProfilePK"] = entry["userProfilePK"]
                     speed_and_heart_rate_dict["version"] = entry["version"]
                     speed_and_heart_rate_dict["calendarDate"] = entry["calendarDate"]
                     speed_and_heart_rate_dict["sequence"] = entry["sequence"]
@@ -677,37 +677,35 @@ class Garmin:
 
                 # Doesn't exist for me but adding it just in case.  We'll check for each entry
                 if entry['heartRateCycling'] is not None:
-                    speed_and_heart_rate_dict["heartRate"] = entry["heartRateCycling"]
+                    speed_and_heart_rate_dict["heartRateCycling"] = entry["heartRateCycling"]
 
-            latest_dict = {
+            return {
                 "speed_and_heart_rate": speed_and_heart_rate_dict,
                 "power": power_dict
             }
-            return latest_dict
 
 
-        else:
-            if start_date is None:
-                raise ValueError("You must either specify 'latest=True' or a start_date")
+        if start_date is None:
+            raise ValueError("You must either specify 'latest=True' or a start_date")
 
-            if end_date is None:
-                end_date = date.today()
+        if end_date is None:
+            end_date = date.today().isoformat()
 
-            _valid_aggregations = {"daily", "weekly", "monthly", "yearly"}
-            if aggregation not in _valid_aggregations:
-                raise ValueError(f"aggregation must be in {_valid_aggregations}")
+        _valid_aggregations = {"daily", "weekly", "monthly", "yearly"}
+        if aggregation not in _valid_aggregations:
+            raise ValueError(f"aggregation must be one of {_valid_aggregations}")
 
-            speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
 
-            heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
 
-            power_url = f"{self.garmin_connect_biometric_stats_url}/functionalThresholdPower/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        power_url = f"{self.garmin_connect_biometric_stats_url}/functionalThresholdPower/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
 
-            speed = self.connectapi(speed_url)
-            heart_rate = self.connectapi(heart_rate_url)
-            power = self.connectapi(power_url)
+        speed = self.connectapi(speed_url)
+        heart_rate = self.connectapi(heart_rate_url)
+        power = self.connectapi(power_url)
 
-            return {"speed": speed, "heart_rate": heart_rate, "power": power}
+        return {"speed": speed, "heart_rate": heart_rate, "power": power}
 
     def add_hydration_data(
         self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -46,7 +46,7 @@ class Garmin:
             "/usersummary-service/usersummary/daily"
         )
         self.garmin_connect_metrics_url = (
-            "/metrics-service/metrics/maxmet/latest"
+            "/metrics-service/metrics/maxmet/daily"
         )
         self.garmin_connect_daily_hydration_url = (
             "/usersummary-service/usersummary/hydration/daily"
@@ -601,7 +601,7 @@ class Garmin:
     def get_max_metrics(self, cdate: str) -> Dict[str, Any]:
         """Return available max metric data for 'cdate' format 'YYYY-MM-DD'."""
 
-        url = f"{self.garmin_connect_metrics_url}/{cdate}"
+        url = f"{self.garmin_connect_metrics_url}/{cdate}/{cdate}"
         logger.debug("Requesting max metrics")
 
         return self.connectapi(url)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -656,7 +656,7 @@ class Garmin:
                 "calendarDate": None,
                 "sequence": None,
                 "speed": None,
-                "hearRate": None,
+                "heartRate": None,
                 "heartRateCycling": None
             }
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -48,6 +48,13 @@ class Garmin:
         self.garmin_connect_metrics_url = (
             "/metrics-service/metrics/maxmet/daily"
         )
+        self.garmin_connect_biometric_url = (
+            "/biometric-service/biometric"
+        )
+
+        self.garmin_connect_biometric_stats_url = (
+            "/biometric-service/stats"
+        )
         self.garmin_connect_daily_hydration_url = (
             "/usersummary-service/usersummary/hydration/daily"
         )
@@ -605,6 +612,90 @@ class Garmin:
         logger.debug("Requesting max metrics")
 
         return self.connectapi(url)
+
+    def get_lactate_threshold(self, latest=True, start_date=None, end_date=None, aggregation="daily") -> Dict:
+        """
+        Returns Running Lactate Threshold information, including heart rate, power, and speed
+
+        :param bool required - latest: Whether to query for the latest Lactate Threshold info or a range.  False if querying a range
+        :param date optional - start_date: The first date in the range to query, format 'YYYY-MM-DD'.  Required if `latest` is False.  Ignored if `latest` is True
+        :param date optional - end_date: The last date in the range to query, format 'YYYY-MM-DD'. Defaults to current data. Ignored if `latest` is True
+        :param str optional - aggregation: How to aggregate the data. Must be one of `daily`, `weekly`, `monthly`, `yearly`.
+
+        """
+
+        if latest:
+
+            speed_and_heart_rate_url = f"{self.garmin_connect_biometric_url}/latestLactateThreshold"
+            power_url = f"{self.garmin_connect_biometric_url}/powerToWeight/latest/{date.today()}?sport=Running"
+
+            power = self.connectapi(power_url)
+            try:
+                power_dict = power[0]
+            except IndexError:
+                # If no power available
+                power_dict = {}
+
+            speed_and_heart_rate = self.connectapi(speed_and_heart_rate_url)
+
+            speed_and_heart_rate_dict = {
+                "userProfilePK": None,
+                "version": None,
+                "calendarDate": None,
+                "sequence": None,
+                "speed": None,
+                "hearRate": None,
+                "heartRateCycling": None
+            }
+
+            # Garmin /latestLactateThreshold endpoint returns a list of two
+            # (or more, if cyclingHeartRate ever gets values) nearly identical dicts.
+            # We're combining them here
+            for entry in speed_and_heart_rate:
+                if entry['speed'] is not None:
+                    speed_and_heart_rate_dict["userProfilePK"] =entry["userProfilePK"]
+                    speed_and_heart_rate_dict["version"] = entry["version"]
+                    speed_and_heart_rate_dict["calendarDate"] = entry["calendarDate"]
+                    speed_and_heart_rate_dict["sequence"] = entry["sequence"]
+                    speed_and_heart_rate_dict["speed"] = entry["speed"]
+
+                # This is not a typo. The Garmin dictionary has a typo as of 2025-07-08, refering to it as "hearRate"
+                elif entry['hearRate'] is not None:
+                    speed_and_heart_rate_dict["heartRate"] = entry["hearRate"] # Fix Garmin's typo
+
+                # Doesn't exist for me but adding it just in case.  We'll check for each entry
+                if entry['heartRateCycling'] is not None:
+                    speed_and_heart_rate_dict["heartRate"] = entry["heartRateCycling"]
+
+            latest_dict = {
+                "speed_and_heart_rate": speed_and_heart_rate_dict,
+                "power": power_dict
+            }
+            return latest_dict
+
+
+        else:
+            if start_date is None:
+                raise ValueError("You must either specify 'latest=True' or a start_date")
+
+            if end_date is None:
+                end_date = date.today()
+
+            _valid_aggregations = {"daily", "weekly", "monthly", "yearly"}
+            if aggregation not in _valid_aggregations:
+                raise ValueError(f"aggregation must be in {_valid_aggregations}")
+
+            speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+
+            heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+
+            power_url = f"{self.garmin_connect_biometric_stats_url}/functionalThresholdPower/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+
+            speed = self.connectapi(speed_url)
+            heart_rate = self.connectapi(heart_rate_url)
+            power = self.connectapi(power_url)
+
+            return {"speed": speed, "heart_rate": heart_rate, "power": power}
 
     def add_hydration_data(
         self, value_in_ml: float, timestamp=None, cdate: Optional[str] = None


### PR DESCRIPTION
Should resolve #270, although it would be helpful if someone could test.  Specifically, I've tried to make sure it works if you don't have available power (or other threshold) data, but it's hard to validate, since I always do.

Also adds the function to `example.py`

I made the choice to have one function that combines the power, heart rate, and speed data into one dict, but let me know if we think we'd rather have the data exposed exactly as it is returned.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menu option to retrieve lactate threshold data from Garmin, showing both the latest value and daily data for the past four weeks.
  * Users can now view lactate threshold metrics for speed, heart rate, and power.
  * Historical queries support date ranges and aggregation (daily/weekly/monthly/yearly) so users can inspect trends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->