### PR TITLE
Add training plans API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Garmin Connect API library comes with two examples:
 
 - **`example.py`** - Simple getting-started example showing authentication, token storage, and basic API calls
-- **`demo.py`** - Comprehensive demo providing access to **100+ API methods** organized into **11 categories** for easy navigation
+- **`demo.py`** - Comprehensive demo providing access to **100+ API methods** organized into **12 categories** for easy navigation
 
 Note: The demo menu is generated dynamically; exact options may change between releases.
 
@@ -24,7 +24,7 @@ Select a category:
   [9] 🎽 Gear & Equipment
   [0] 💧 Hydration & Wellness
   [a] 🔧 System & Export
-  [b] 📅 Training plans 
+  [b] 📅 Training plans
 
   [q] Exit program
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -266,7 +266,7 @@ class Garmin:
 
         self.garmin_graphql_endpoint = "graphql-gateway/graphql"
 
-        self.garmin_training_plan_url = "/trainingplan-service/trainingplan"
+        self.garmin_connect_training_plan_url = "/trainingplan-service/trainingplan"
 
         self.garth = garth.Client(
             domain="garmin.cn" if is_cn else "garmin.com",
@@ -2168,7 +2168,7 @@ class Garmin:
     def get_training_plans(self) -> dict[str, Any]:
         """Return all available training plans."""
 
-        url = f"{self.garmin_training_plan_url}/plans"
+        url = f"{self.garmin_connect_training_plan_url}/plans"
         logger.debug("Requesting training plans.")
         return self.connectapi(url)
 
@@ -2177,7 +2177,7 @@ class Garmin:
 
         plan_id = _validate_positive_integer(int(plan_id), "plan_id")
 
-        url = f"{self.garmin_training_plan_url}/plans/{plan_id}"
+        url = f"{self.garmin_connect_training_plan_url}/plans/{plan_id}"
         logger.debug("Requesting training plan details for %s", plan_id)
         return self.connectapi(url)
 
@@ -2185,7 +2185,7 @@ class Garmin:
         """Return details for a specific adaptive training plan."""
 
         plan_id = _validate_positive_integer(int(plan_id), "plan_id")
-        url = f"{self.garmin_training_plan_url}/fbt-adaptive/{plan_id}"
+        url = f"{self.garmin_connect_training_plan_url}/fbt-adaptive/{plan_id}"
 
         logger.debug("Requesting adaptive training plan details for %s", plan_id)
         return self.connectapi(url)


### PR DESCRIPTION
I have added support for fetching training plan data. 

There are 3 endpoints added: 
- `get_training_plans()` - Retrieve all available training plans
- `get_training_plan_by_id()` - Get details for a specific training plan
- `get_adaptive_training_plan_by_id()` - Get details for adaptive training plans

There are more training plan endpoints, like Strength Training Plans, Phased Training Plans, but this is a start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “📅 Training Plans” top-level menu.
  - Browse all available training plans.
  - Retrieve a specific training plan by ID, including adaptive plans when applicable.

- **Documentation**
  - README updated to include the Training Plans category, API coverage (3 methods), and adjusted category count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->