### PR TITLE
Fixed bug with an error happening on add_weight_in

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -90,6 +90,11 @@ def _fmt_ts(dt: datetime) -> str:
     # Use ms precision to match server expectations
     return dt.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
 
+def _validate_json_exists(response: requests.Response) -> dict[str, Any] | None:
+     if response.status_code == 204:
+        return None
+     return response.json()
+
 
 class Garmin:
     """Class for fetching data from Garmin Connect."""
@@ -681,7 +686,7 @@ class Garmin:
 
     def add_weigh_in(
         self, weight: int | float, unitKey: str = "kg", timestamp: str = ""
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """Add a weigh-in (default to kg)"""
 
         # Validate inputs
@@ -707,8 +712,7 @@ class Garmin:
             "value": weight,
         }
         logger.debug("Adding weigh-in")
-
-        return self.garth.post("connectapi", url, json=payload).json()
+        return _validate_json_exists(self.garth.post("connectapi", url, json=payload))
 
     def add_weigh_in_with_timestamps(
         self,
@@ -716,7 +720,7 @@ class Garmin:
         unitKey: str = "kg",
         dateTimestamp: str = "",
         gmtTimestamp: str = "",
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """Add a weigh-in with explicit timestamps (default to kg)"""
 
         url = f"{self.garmin_connect_weight_url}/user-weight"
@@ -753,7 +757,7 @@ class Garmin:
         logger.debug("Adding weigh-in with explicit timestamps: %s", payload)
 
         # Make the POST request
-        return self.garth.post("connectapi", url, json=payload).json()
+        return _validate_json_exists(self.garth.post("connectapi", url, json=payload))
 
     def get_weigh_ins(self, startdate: str, enddate: str) -> dict[str, Any]:
         """Get weigh-ins between startdate and enddate using format 'YYYY-MM-DD'."""


### PR DESCRIPTION
Added a validation method that only returns a response in json if the response status code isn't 204.
This fixed https://github.com/cyberjunky/python-garminconnect/issues/283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved handling of responses when adding weight entries, including cases with no content returned.
- Bug Fixes
  - Fixed occasional errors when adding weigh-ins that could occur due to empty server responses.
- Improvements
  - More consistent and predictable results when adding weigh-ins, with or without timestamps.
  - Enhanced reliability of weight entry submissions, reducing ambiguity in response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->