### PR TITLE
Add activities count endpoint and method to retrieve total activities

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1526,7 +1526,7 @@ class Garmin:
         logger.debug("Requesting activities count")
 
         activities_count = self.connectapi(url)
-        if activities_count is None:
+        if not activities_count or "totalCount" not in activities_count:
             raise GarminConnectConnectionError("No activities count data received")
         return activities_count["totalCount"]
 


### PR DESCRIPTION
PR to add a activities count endpoint
So we can have the total activities and use the start and the limit from get_activities endpoint with more knowledge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve your total activity count from Garmin Connect for quick access to activity statistics and summaries.
  * Provides a clear result suitable for dashboards and summary screens, with graceful handling and user-facing error reporting when the service does not return data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->