### PR TITLE
Fix training plan retrieval by updating API endpoint

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2298,7 +2298,7 @@ class Garmin:
 
         plan_id = _validate_positive_integer(int(plan_id), "plan_id")
 
-        url = f"{self.garmin_connect_training_plan_url}/plans/{plan_id}"
+        url = f"{self.garmin_connect_training_plan_url}/phased/{plan_id}"
         logger.debug("Requesting training plan details for %s", plan_id)
         return self.connectapi(url)
 


### PR DESCRIPTION
This PR fixes issue #309.

The `get_training_plan_by_id` method was using an incorrect API endpoint:

- Previous: /trainingplan-service/trainingplan/plans/{id}
- Fixed: /trainingplan-service/trainingplan/phased/{id}

The old endpoint consistently returned 404 Not Found. Updating to the correct phased endpoint restores proper training plan retrieval.

Executing the same test reproduced in the issue now returns the expected result:

```
📋 #b 📅 Training Plans - Options
----------------------------------------
  [1] Get training plans
  [2] Get training plan by ID

  [q] Back to main menu

Make your selection: 
🔄 Executing: get_training_plan_by_id
Enter training plan ID (press Enter for most recent): 

📡 API Call: api.get_training_plan_by_id(41930814) - Piano GF Strade Bianche
--------------------------------------------------
{
  "trainingPlanId": 41930814,
  "trainingPlanCategory": "ITP",
  "trainingType": {
    "typeId": 3,
    "typeKey": "Cycling"
  },
  // ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the training plan retrieval endpoint to access the proper resource, ensuring training plan data is fetched accurately from the updated location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->