### PR TITLE
Fix maxpoly arg to get_activity_details() to allow 0 value

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2127,7 +2127,7 @@ class Garmin:
 
         activity_id = str(activity_id)
         maxchart = _validate_positive_integer(maxchart, "maxchart")
-        maxpoly = _validate_positive_integer(maxpoly, "maxpoly")
+        maxpoly = _validate_non_negative_integer(maxpoly, "maxpoly")
         params = {"maxChartSize": str(maxchart), "maxPolylineSize": str(maxpoly)}
         url = f"{self.garmin_connect_activity}/{activity_id}/details"
         logger.debug("Requesting details for activity id %s", activity_id)


### PR DESCRIPTION
The best way to get the details of an activity when not interested in polylines is:
```py
get_activity_details(..., maxploy=0)
```
The 0 value is allowed by the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Relaxed validation constraints for activity details configuration parameters to allow zero as a valid value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->