### PR TITLE
Time in power zones for activities

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2119,6 +2119,18 @@ class Garmin:
         logger.debug("Requesting Power time-in-zones for activity id %s", activity_id)
 
         return self.connectapi(url)
+    
+    def get_cycling_ftp(
+        self,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Return cycling Functional Threshold Power (FTP) information.
+        """
+
+        url = f"{self.garmin_connect_biometric_url}/latestFunctionalThresholdPower/CYCLING"
+        logger.debug("Requesting latest cycling FTP")
+        return self.connectapi(url)
+
 
     def get_activity(self, activity_id: str) -> dict[str, Any]:
         """Return activity summary, including basic splits."""


### PR DESCRIPTION
Added a API call to get time in power zones for activities. 
Works for activity types: virtual_ride, cycling, indoor_ride, running (and more)
If not available returns empty list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve power-zone metrics for an activity, showing time spent in each power zone.
  * Fetch latest cycling Functional Threshold Power (FTP) data for the user, returning current FTP information or recent entries as available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->