### PR TITLE
add readchar to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "garth>=0.5.17,<0.6.0",
+    "readchar>=4.2.1",
 ]
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
I tried to setup the environment via uv (uv sync) and when trying to execute demo.py, readchar was not installed properly (due to not being in pyproject).

I have included it and I think it shall be included in the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->