### PR TITLE
docs: use correct link for demo ipynb

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ git push origin your-branch
 
 ### Jupyter Notebook
 
-Explore the API interactively with our [reference notebook](https://github.com/cyberjunky/python-garminconnect/blob/master/reference.ipynb).
+Explore the API interactively with our [reference notebook](https://github.com/cyberjunky/python-garminconnect/blob/master/docs/reference.ipynb).
 
 ### Python Code Examples
 


### PR DESCRIPTION
Looks like the README was not updated last time the reference ipynb was moved to the `docs` directory, leading to a broken link. Updating to point to correct location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jupyter Notebook reference link in the README to point to the documentation subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->