### PR TITLE
Tokens not saved to disk after fresh credential login

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1,5 +1,6 @@
 """Python 3 API wrapper for Garmin Connect."""
 
+import contextlib
 import logging
 import numbers
 import os
@@ -420,6 +421,7 @@ class Garmin:
 
             # Try to load tokens from tokenstore if provided
             tokens_loaded = False
+            tokenstore_path = None
             if tokenstore:
                 try:
                     if len(tokenstore) > 512:
@@ -429,9 +431,9 @@ class Garmin:
                         # Tokenstore is a path - normalize it for cross-platform compatibility
                         # This fixes Windows path issues where ~ expansion or path separators
                         # might cause token extraction to not find all token files correctly
-                        tokenstore_path = Path(tokenstore).expanduser().resolve()
+                        tokenstore_path = str(Path(tokenstore).expanduser().resolve())
                         # Convert to string with normalized path separators
-                        normalized_path = str(tokenstore_path)
+                        normalized_path = tokenstore_path
                         logger.debug(
                             f"Loading tokens from normalized path: {normalized_path}"
                         )
@@ -470,15 +472,17 @@ class Garmin:
                     )
                     # In MFA early-return mode, profile/settings are not loaded yet
                     return mfa_status, _legacy_token
-                self.client._tokenstore_path = tokenstore_path
+                if tokenstore_path is not None:
+                    self.client._tokenstore_path = tokenstore_path
                 mfa_status, _legacy_token = self.client.login(
                     self.username,
                     self.password,
                     prompt_mfa=self.prompt_mfa,
                 )
                 # Persist tokens so next run restores without re-login/MFA
-                if tokenstore:
-                    self.client.dump(tokenstore_path)
+                if tokenstore_path is not None:
+                    with contextlib.suppress(Exception):
+                        self.client.dump(tokenstore_path)
                 # Continue to load profile/settings below
 
             # Ensure profile is loaded (tokenstore path may not populate it)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -470,11 +470,15 @@ class Garmin:
                     )
                     # In MFA early-return mode, profile/settings are not loaded yet
                     return mfa_status, _legacy_token
+                self.client._tokenstore_path = tokenstore_path
                 mfa_status, _legacy_token = self.client.login(
                     self.username,
                     self.password,
                     prompt_mfa=self.prompt_mfa,
                 )
+                # Persist tokens so next run restores without re-login/MFA
+                if tokenstore:
+                    self.client.dump(tokenstore_path)
                 # Continue to load profile/settings below
 
             # Ensure profile is loaded (tokenstore path may not populate it)


### PR DESCRIPTION
After the garth replacement ([21aea2d](https://github.com/cyberjunky/python-garminconnect/commit/21aea2d95b823a15c81a3efe87566de5dcc3befc)), `Garmin.login()` calls `client.load()`  when restoring existing tokens, which sets `_tokenstore_path` as a side effect. On a fresh credential login however, it called `client.login()` directly without ever setting `_tokenstore_path`. The `dump()` calls inside `_refresh_session()` therefore never fired, and the initial tokens were never written to disk at all which forced a full login + MFA prompt on every single run regardless of the tokenstore path provided.

Fix: set `client._tokenstore_path` before calling `client.login()` so that in-session auto-refreshes also persist correctly, then explicitly call `client.dump()` after a successful fresh login when a tokenstore path was provided.

To reproduce: set `GARMINTOKENS` to any directory, delete any existing `garmin_tokens.json`, run `example.py` through a full MFA login, and the token file was never created. With this fix the file is written immediately after login completes and subsequent runs restore the session without prompting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token handling: token storage paths are now normalized and reliably recorded, tokens are persisted after successful credential logins, and errors during token persistence are safely suppressed to avoid interrupting login flows.
  * Enhances session persistence across restarts and after multi-factor authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->