### PR TITLE
Add get_scheduled_workouts_by_year_and_month to demo and API

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -332,6 +332,10 @@ menu_categories = {
                 "desc": f"Import activity (no Strava re-export) from {config.activityfile}",
                 "key": "import_activity",
             },
+            "u": {
+                "desc": "Get scheduled workouts by year and month",
+                "key": "get_scheduled_workouts_by_year_and_month",
+            },
             "v": {
                 "desc": "Upload typed running workout (sample)",
                 "key": "upload_running_workout",
@@ -2490,6 +2494,30 @@ def schedule_workout_data(api: Garmin) -> None:
         print(f"❌ Error scheduling workout: {e}")
 
 
+def get_scheduled_workouts_by_year_and_month(api: Garmin) -> None:
+    """Get scheduled workout by year and month."""
+    try:
+        year_input = input("Enter year (YYYY): ").strip()
+        month_input = input("Enter month (1-12): ").strip()
+
+        if not year_input or not month_input:
+            print("❌ Year and month are required")
+            return
+
+        year = int(year_input)
+        month = int(month_input)
+
+        call_and_display(
+            api.get_scheduled_workouts_by_year_and_month,
+            year,
+            month,
+            method_name="get_scheduled_workouts_by_year_and_month",
+            api_call_desc=f"api.get_scheduled_workouts_by_year_and_month({year}, {month})",
+        )
+    except Exception as e:
+        print(f"❌ Error getting scheduled workouts by year and month: {e}")
+
+
 def get_scheduled_workout_by_id_data(api: Garmin) -> None:
     """Get scheduled workout by ID."""
     try:
@@ -3933,6 +3961,9 @@ def execute_api_call(api: Garmin, key: str) -> None:
             "upload_walking_workout": lambda: upload_walking_workout_data(api),
             "upload_hiking_workout": lambda: upload_hiking_workout_data(api),
             "get_scheduled_workout_by_id": lambda: get_scheduled_workout_by_id_data(
+                api
+            ),
+            "get_scheduled_workouts_by_year_and_month": lambda: get_scheduled_workouts_by_year_and_month(
                 api
             ),
             "scheduled_workout": lambda: schedule_workout_data(api),

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2733,7 +2733,7 @@ class Garmin:
         """Return scheduled workout by year and month."""
         year = _validate_positive_integer(int(year), "year")
         if year < 2000:
-            raise ValueError(f"year must be after 2000, got: {year}")
+            raise ValueError(f"year must be 2000 or later, got: {year}")
 
         month = _validate_positive_integer(int(month), "month")
         if month < 1 or month > 12:

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -283,6 +283,9 @@ class Garmin:
 
         self.garmin_workouts_schedule_url = f"{self.garmin_workouts}/schedule"
 
+        self.garmin_calendar = "/calendar-service"
+        self.garmin_scheduled_workouts_url = f"{self.garmin_calendar}"
+
         self.garmin_nutrition = "/nutrition-service"
 
         self.garmin_connect_nutrition_daily_food_logs = (
@@ -2723,6 +2726,25 @@ class Garmin:
                 "Pydantic is required for typed workouts. "
                 "Install it with: pip install pydantic or pip install garminconnect[workout]"
             ) from None
+
+    def get_scheduled_workouts_by_year_and_month(
+        self, year: int | str, month: int | str
+    ) -> dict[str, Any]:
+        """Return scheduled workout by year and month."""
+        year = _validate_positive_integer(int(year), "year")
+        if year < 2000:
+            raise ValueError(f"year must be after 2000, got: {year}")
+
+        month = _validate_positive_integer(int(month), "month")
+        if month < 1 or month > 12:
+            raise ValueError(f"month must be between 1 and 12, got: {month}")
+
+        # Garmin's API uses 0-indexed months, so we need to subtract 1 from the month value
+        url = f"{self.garmin_scheduled_workouts_url}/year/{year}/month/{month - 1}"
+        logger.debug(
+            "Requesting scheduled workout for year %d and month %d", year, month
+        )
+        return self.connectapi(url)
 
     def get_scheduled_workout_by_id(
         self, scheduled_workout_id: int | str


### PR DESCRIPTION
Add endpoint to retrieving schedules workouts by year and month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menu option to retrieve scheduled workouts by year and month. Prompts for year/month with input validation and displays matching scheduled workouts in an organized view for easy review of a selected time period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->