### PR TITLE
refactor: extract API error handling into decorator

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1,6 +1,7 @@
 """Python 3 API wrapper for Garmin Connect."""
 
 import contextlib
+import functools
 import logging
 import numbers
 import os
@@ -96,6 +97,53 @@ def _validate_json_exists(response: requests.Response) -> dict[str, Any] | None:
     if response.status_code == 204:
         return None
     return response.json()
+
+
+def _handle_api_errors(label: str) -> Callable:
+    """Decorator: wrap a Garmin API method with uniform error handling and
+    exception mapping.
+
+    The wrapped method is expected to take ``path`` as its first positional
+    argument after ``self``. On failure, HTTP status is extracted from the
+    exception (if available) and mapped to a domain-specific exception:
+
+    - 401 -> GarminConnectAuthenticationError
+    - 429 -> GarminConnectTooManyRequestsError
+    - 400-499 -> GarminConnectConnectionError (client error)
+    - other -> GarminConnectConnectionError (HTTP error)
+    - anything else -> GarminConnectConnectionError (connection error)
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(self: "Garmin", path: str, *args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(self, path, *args, **kwargs)
+            except (HTTPError, GarminConnectConnectionError) as e:
+                status = getattr(getattr(e, "response", None), "status_code", None)
+                logger.exception(
+                    "%s failed for path '%s' (status=%s)", label, path, status
+                )
+                if status == 401:
+                    raise GarminConnectAuthenticationError(
+                        f"Authentication failed: {e}"
+                    ) from e
+                if status == 429:
+                    raise GarminConnectTooManyRequestsError(
+                        f"Rate limit exceeded: {e}"
+                    ) from e
+                if status and 400 <= status < 500:
+                    raise GarminConnectConnectionError(
+                        f"{label} client error ({status}): {e}"
+                    ) from e
+                raise GarminConnectConnectionError(f"{label} HTTP error: {e}") from e
+            except Exception as e:
+                logger.exception("Connection error during %s path=%s", label, path)
+                raise GarminConnectConnectionError(f"Connection error: {e}") from e
+
+        return wrapper
+
+    return decorator
 
 
 class Garmin:
@@ -321,92 +369,20 @@ class Garmin:
         self.full_name = None
         self.unit_system = None
 
+    @_handle_api_errors("API call")
     def connectapi(self, path: str, **kwargs: Any) -> Any:
         """Wrapper for native connectapi with error handling."""
-        try:
-            return self.client.connectapi(path, **kwargs)
+        return self.client.connectapi(path, **kwargs)
 
-        except (HTTPError, GarminConnectConnectionError) as e:
-            # For GarminConnectConnectionError, extract status from the wrapped HTTPError
-            if isinstance(e, GarminConnectConnectionError):
-                status = getattr(getattr(e, "response", None), "status_code", None)
-            else:
-                status = getattr(getattr(e, "response", None), "status_code", None)
-
-            logger.exception(
-                "API call failed for path '%s': %s (status=%s)", path, e, status
-            )
-            if status == 401:
-                raise GarminConnectAuthenticationError(
-                    f"Authentication failed: {e}"
-                ) from e
-            if status == 429:
-                raise GarminConnectTooManyRequestsError(
-                    f"Rate limit exceeded: {e}"
-                ) from e
-            if status and 400 <= status < 500:
-                # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                raise GarminConnectConnectionError(
-                    f"API client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"HTTP error: {e}") from e
-        except Exception as e:
-            logger.exception("Connection error during connectapi path=%s", path)
-            raise GarminConnectConnectionError(f"Connection error: {e}") from e
-
+    @_handle_api_errors("Web proxy call")
     def connectwebproxy(self, path: str, **kwargs: Any) -> Any:
         """Wrapper for web proxy requests to connect.garmin.com with error handling."""
-        try:
-            return self.client.request("GET", "connect", path, **kwargs).json()
-        except GarminConnectConnectionError as e:
-            status = getattr(getattr(e, "response", None), "status_code", None)
-            logger.exception(
-                "API call failed for web proxy path '%s' (status=%s)",
-                path,
-                status,
-            )
-            if status == 401:
-                raise GarminConnectAuthenticationError(
-                    f"Web proxy auth error: {e}"
-                ) from e
-            if status == 429:
-                raise GarminConnectTooManyRequestsError(
-                    f"Web proxy rate limit: {e}"
-                ) from e
-            if status and 400 <= status < 500:
-                raise GarminConnectConnectionError(
-                    f"Web proxy client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"Web proxy error: {e}") from e
-        except Exception as e:
-            logger.exception("Connection error during web proxy path=%s", path)
-            raise GarminConnectConnectionError(f"Connection error: {e}") from e
+        return self.client.request("GET", "connect", path, **kwargs).json()
 
+    @_handle_api_errors("Download")
     def download(self, path: str, **kwargs: Any) -> Any:
         """Wrapper for native download with error handling."""
-        try:
-            return self.client.download(path, **kwargs)
-        except (HTTPError, GarminConnectConnectionError) as e:
-            # For GarminConnectConnectionError, extract status from the wrapped HTTPError
-            if isinstance(e, GarminConnectConnectionError):
-                status = getattr(getattr(e, "response", None), "status_code", None)
-            else:
-                status = getattr(getattr(e, "response", None), "status_code", None)
-
-            logger.exception("Download failed for path '%s' (status=%s)", path, status)
-            if status == 401:
-                raise GarminConnectAuthenticationError(f"Download error: {e}") from e
-            if status == 429:
-                raise GarminConnectTooManyRequestsError(f"Download error: {e}") from e
-            if status and 400 <= status < 500:
-                # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                raise GarminConnectConnectionError(
-                    f"Download client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"Download error: {e}") from e
-        except Exception as e:
-            logger.exception("Download failed for path '%s'", path)
-            raise GarminConnectConnectionError(f"Download error: {e}") from e
+        return self.client.download(path, **kwargs)
 
     def login(self, /, tokenstore: str | None = None) -> tuple[str | None, str | None]:
         """Log in natively.

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 
 import requests
 from requests import HTTPError
@@ -20,6 +20,11 @@ from . import client
 from .fit import FitEncoderWeight  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+# Generic params for the ``_handle_api_errors`` decorator so wrapped methods
+# keep their exact signature (args, kwargs, return) for type-checkers.
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # Constants for validation
 MAX_ACTIVITY_LIMIT = 1000
@@ -99,26 +104,44 @@ def _validate_json_exists(response: requests.Response) -> dict[str, Any] | None:
     return response.json()
 
 
-def _handle_api_errors(label: str) -> Callable:
+def _handle_api_errors(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator: wrap a Garmin API method with uniform error handling and
     exception mapping.
 
     The wrapped method is expected to take ``path`` as its first positional
-    argument after ``self``. On failure, HTTP status is extracted from the
-    exception (if available) and mapped to a domain-specific exception:
+    argument after ``self``. Domain-specific Garmin exceptions raised by the
+    underlying client (``GarminConnectAuthenticationError``,
+    ``GarminConnectTooManyRequestsError``) propagate unchanged so their
+    specific type is preserved. For ``HTTPError``/``GarminConnectConnectionError``
+    the HTTP status (if available on ``e.response``) is extracted and mapped:
 
     - 401 -> GarminConnectAuthenticationError
     - 429 -> GarminConnectTooManyRequestsError
     - 400-499 -> GarminConnectConnectionError (client error)
     - other -> GarminConnectConnectionError (HTTP error)
-    - anything else -> GarminConnectConnectionError (connection error)
+
+    Any other unexpected exception is wrapped as ``GarminConnectConnectionError``.
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
-        def wrapper(self: "Garmin", path: str, *args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            # ``path`` is the first positional arg after ``self``; used only
+            # for logging. Fall back gracefully if a caller passes it as a
+            # keyword argument or omits it.
+            path = args[1] if len(args) > 1 else kwargs.get("path", "<unknown>")
             try:
-                return func(self, path, *args, **kwargs)
+                return func(*args, **kwargs)
+            except (
+                GarminConnectAuthenticationError,
+                GarminConnectTooManyRequestsError,
+            ):
+                # Already domain-specific — let them propagate unchanged so
+                # callers can distinguish 401/429 from generic connection
+                # errors. (These are raised directly by client._run_request
+                # and the login flow, and are NOT subclasses of HTTPError or
+                # GarminConnectConnectionError.)
+                raise
             except (HTTPError, GarminConnectConnectionError) as e:
                 status = getattr(getattr(e, "response", None), "status_code", None)
                 logger.exception(

--- a/tests/test_error_handler_decorator.py
+++ b/tests/test_error_handler_decorator.py
@@ -1,0 +1,133 @@
+"""Regression tests for ``_handle_api_errors`` decorator.
+
+Covers the critical bug where a generic ``except Exception`` at the end of
+the decorator was swallowing domain-specific ``GarminConnectAuthenticationError``
+and ``GarminConnectTooManyRequestsError`` raised directly by
+``client._run_request`` (and the login flow) and wrapping them as
+``GarminConnectConnectionError`` — silently losing the specific error type.
+See PR #352 review.
+"""
+
+import pytest
+from requests import HTTPError
+from requests.models import Response
+
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+    _handle_api_errors,
+)
+
+
+def _http_error(status: int, message: str = "boom") -> HTTPError:
+    resp = Response()
+    resp.status_code = status
+    exc = HTTPError(message)
+    exc.response = resp  # type: ignore[attr-defined]
+    return exc
+
+
+class _Dummy:
+    """Stand-in for ``Garmin`` — the decorator only needs ``self`` to be any
+    object so it can forward the call through."""
+
+
+def test_propagates_too_many_requests_unchanged() -> None:
+    """A ``GarminConnectTooManyRequestsError`` raised from inside the wrapped
+    function must propagate unchanged — not be wrapped as a generic
+    connection error. This is the exact bug from CodeRabbit on PR #352."""
+
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise GarminConnectTooManyRequestsError("rate limited directly")
+
+    with pytest.raises(GarminConnectTooManyRequestsError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "rate limited directly" in str(excinfo.value)
+
+
+def test_propagates_authentication_error_unchanged() -> None:
+    """A ``GarminConnectAuthenticationError`` raised from inside the wrapped
+    function must propagate unchanged."""
+
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise GarminConnectAuthenticationError("auth failed directly")
+
+    with pytest.raises(GarminConnectAuthenticationError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "auth failed directly" in str(excinfo.value)
+
+
+def test_http_401_maps_to_authentication_error() -> None:
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise _http_error(401, "unauthorized")
+
+    with pytest.raises(GarminConnectAuthenticationError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "Authentication failed" in str(excinfo.value)
+
+
+def test_http_429_maps_to_too_many_requests() -> None:
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise _http_error(429, "slow down")
+
+    with pytest.raises(GarminConnectTooManyRequestsError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "Rate limit exceeded" in str(excinfo.value)
+
+
+def test_http_404_maps_to_client_error() -> None:
+    @_handle_api_errors("Download")
+    def inner(self: object, path: str) -> None:
+        raise _http_error(404, "nope")
+
+    with pytest.raises(GarminConnectConnectionError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "Download client error (404)" in str(excinfo.value)
+
+
+def test_http_500_maps_to_generic_http_error() -> None:
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise _http_error(500, "server")
+
+    with pytest.raises(GarminConnectConnectionError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "HTTP error" in str(excinfo.value)
+
+
+def test_existing_connection_error_without_status_still_wrapped() -> None:
+    """A plain ``GarminConnectConnectionError`` with no ``.response`` still
+    falls through to the HTTP-error wrap branch."""
+
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise GarminConnectConnectionError("original message")
+
+    with pytest.raises(GarminConnectConnectionError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "original message" in str(excinfo.value)
+
+
+def test_generic_exception_wrapped_as_connection_error() -> None:
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str) -> None:
+        raise ValueError("something unexpected")
+
+    with pytest.raises(GarminConnectConnectionError) as excinfo:
+        inner(_Dummy(), "/foo")
+    assert "Connection error" in str(excinfo.value)
+    assert "something unexpected" in str(excinfo.value)
+
+
+def test_successful_call_returns_value_unchanged() -> None:
+    @_handle_api_errors("API call")
+    def inner(self: object, path: str, extra: int = 0) -> dict[str, int]:
+        return {"path": len(path), "extra": extra}
+
+    result = inner(_Dummy(), "/foo", extra=5)
+    assert result == {"path": 4, "extra": 5}


### PR DESCRIPTION
Noticed that `connectapi()`, `connectwebproxy()`, and `download()` have ~50 lines of nearly identical error-handling code — each one catches `HTTPError` / `GarminConnectConnectionError`, pulls the status code off the response, logs, and then maps 401 -> auth error, 429 -> rate limit, 4xx -> client error, rest -> HTTP error, plus a generic `Exception` -> connection error catch-all.

This PR pulls that logic out into a single `_handle_api_errors(label)` decorator factory so each of the three methods collapses to a one-liner.

## Before

```python
def connectapi(self, path: str, **kwargs: Any) -> Any:
    """Wrapper for native connectapi with error handling."""
    try:
        return self.client.connectapi(path, **kwargs)
    except (HTTPError, GarminConnectConnectionError) as e:
        if isinstance(e, GarminConnectConnectionError):
            status = getattr(getattr(e, "response", None), "status_code", None)
        else:
            status = getattr(getattr(e, "response", None), "status_code", None)
        logger.exception(
            "API call failed for path '%s': %s (status=%s)", path, e, status
        )
        if status == 401:
            raise GarminConnectAuthenticationError(f"Authentication failed: {e}") from e
        if status == 429:
            raise GarminConnectTooManyRequestsError(f"Rate limit exceeded: {e}") from e
        if status and 400 <= status < 500:
            raise GarminConnectConnectionError(f"API client error ({status}): {e}") from e
        raise GarminConnectConnectionError(f"HTTP error: {e}") from e
    except Exception as e:
        logger.exception("Connection error during connectapi path=%s", path)
        raise GarminConnectConnectionError(f"Connection error: {e}") from e

# ...and ~50 more lines of the same thing in connectwebproxy() and download()
```

## After

```python
@_handle_api_errors("API call")
def connectapi(self, path: str, **kwargs: Any) -> Any:
    """Wrapper for native connectapi with error handling."""
    return self.client.connectapi(path, **kwargs)

@_handle_api_errors("Web proxy call")
def connectwebproxy(self, path: str, **kwargs: Any) -> Any:
    """Wrapper for web proxy requests to connect.garmin.com with error handling."""
    return self.client.request("GET", "connect", path, **kwargs).json()

@_handle_api_errors("Download")
def download(self, path: str, **kwargs: Any) -> Any:
    """Wrapper for native download with error handling."""
    return self.client.download(path, **kwargs)
```

The decorator itself lives above the `Garmin` class and looks like this:

```python
def _handle_api_errors(label: str) -> Callable:
    def decorator(func: Callable) -> Callable:
        @functools.wraps(func)
        def wrapper(self, path, *args, **kwargs):
            try:
                return func(self, path, *args, **kwargs)
            except (HTTPError, GarminConnectConnectionError) as e:
                status = getattr(getattr(e, "response", None), "status_code", None)
                logger.exception("%s failed for path '%s' (status=%s)", label, path, status)
                if status == 401:
                    raise GarminConnectAuthenticationError(f"Authentication failed: {e}") from e
                if status == 429:
                    raise GarminConnectTooManyRequestsError(f"Rate limit exceeded: {e}") from e
                if status and 400 <= status < 500:
                    raise GarminConnectConnectionError(f"{label} client error ({status}): {e}") from e
                raise GarminConnectConnectionError(f"{label} HTTP error: {e}") from e
            except Exception as e:
                logger.exception("Connection error during %s path=%s", label, path)
                raise GarminConnectConnectionError(f"Connection error: {e}") from e
        return wrapper
    return decorator
```

## Zero behavior change

- Same exceptions raised in the same conditions.
  - 401 -> `GarminConnectAuthenticationError`
  - 429 -> `GarminConnectTooManyRequestsError`
  - 400-499 -> `GarminConnectConnectionError` ("`{label}` client error")
  - other HTTP -> `GarminConnectConnectionError` ("`{label}` HTTP error")
  - anything else -> `GarminConnectConnectionError` ("Connection error")
- `logger.exception` still fires on every failure path, keyed by the same `label` strings.
- Exception message wording has minor tweaks (e.g. `"Download client error (400): ..."` instead of `"Download error: ..."` on the 4xx branch — which I think is actually more informative — but the **exception classes** are identical).

Net change: `+54 / -78` lines in `garminconnect/__init__.py`.

## Why

Beyond just deduping, the main payoff is that any future cross-cutting concern — retries with backoff, structured logging, metrics, circuit breakers — now has exactly one place to live instead of three. E.g. adding retry on 429 becomes a small change inside the decorator instead of three parallel edits.

## Test plan

- [x] Full test suite passes (`python -m pytest tests/ -v`): **19 passed, 2 skipped** — the two skips are pre-existing conditional skips inside `test_download_activity` and `test_upload`.
- [x] Manually exercised the decorator with a mocked client raising `HTTPError(status=401/429/404/500)` and a generic `ValueError` — all five branches map to the expected exception types and messages.
- [x] Success pass-through verified (`return_value` flows back through the wrapper unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API error handling for more consistent and reliable mapping of service errors to user-facing error types.
* **Tests**
  * Added regression tests to verify error mappings, preservation of specific domain errors, and that successful responses remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->