### PR TITLE
feat: add configurable retry with exponential backoff for transient errors

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -134,13 +134,32 @@ def _extract_status_code(exc: BaseException) -> int | None:
     return None
 
 
+def _has_network_cause(exc: BaseException) -> bool:
+    """Return True if the exception's cause chain includes a raw network error.
+
+    Walks ``__cause__`` / ``__context__`` looking for ``requests.ConnectionError``
+    or ``requests.Timeout``. Used to decide whether a status-less
+    ``GarminConnectConnectionError`` is actually a transient network failure
+    (retry) or a deterministic logic / decode error (do not retry).
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, (requests.ConnectionError, requests.Timeout)):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
 def _is_retryable_error(exc: BaseException) -> bool:
     """Return True for transient errors worth retrying.
 
     Retries:
     - ``GarminConnectConnectionError`` with a 5xx status (server errors).
-    - ``GarminConnectConnectionError`` with no detectable status (network /
-      connection failures where the request never got a response).
+    - ``GarminConnectConnectionError`` whose cause chain contains a raw
+      ``requests.ConnectionError`` or ``requests.Timeout`` (true network
+      failures where the request never got a response).
     - Raw ``requests`` network errors (connection / timeout) from lower
       layers that escape without being wrapped.
 
@@ -148,6 +167,9 @@ def _is_retryable_error(exc: BaseException) -> bool:
     - ``GarminConnectAuthenticationError`` (401 — user must re-login).
     - ``GarminConnectTooManyRequestsError`` (429 — caller should back off).
     - Any error with a 4xx status code.
+    - Status-less ``GarminConnectConnectionError`` with no network cause
+      (e.g. JSON decode errors, ``AttributeError``, programming bugs).
+      Retrying these would be pointless and waste time.
     """
     # Never retry auth failures or rate-limit errors.
     if isinstance(
@@ -158,8 +180,10 @@ def _is_retryable_error(exc: BaseException) -> bool:
     if isinstance(exc, GarminConnectConnectionError):
         status = _extract_status_code(exc)
         if status is None:
-            # Network error / no response — treat as transient.
-            return True
+            # Only retry when we can confirm the underlying cause was an
+            # actual network failure — not a deterministic error wrapped in
+            # a generic GarminConnectConnectionError.
+            return _has_network_cause(exc)
         return 500 <= status < 600
 
     # Raw network errors from requests that somehow escaped the wrappers.
@@ -451,17 +475,19 @@ class Garmin:
         )
 
     def _connectapi_once(self, path: str, **kwargs: Any) -> Any:
-        """Single (non-retried) connectapi call with error translation."""
+        """Single (non-retried) connectapi call with error translation.
+
+        On auth (401) and rate-limit (429) we translate to the dedicated
+        exception types. All other ``GarminConnectConnectionError`` instances
+        are re-raised unchanged so callers (e.g. ``get_gear_stats``) can still
+        read ``.response.status_code`` and any other attributes attached by
+        the lower-level client.
+        """
         try:
             return self.client.connectapi(path, **kwargs)
 
-        except (HTTPError, GarminConnectConnectionError) as e:
-            # For GarminConnectConnectionError, extract status from the wrapped HTTPError
-            if isinstance(e, GarminConnectConnectionError):
-                status = _extract_status_code(e)
-            else:
-                status = getattr(getattr(e, "response", None), "status_code", None)
-
+        except GarminConnectConnectionError as e:
+            status = _extract_status_code(e)
             logger.exception(
                 "API call failed for path '%s': %s (status=%s)", path, e, status
             )
@@ -473,19 +499,28 @@ class Garmin:
                 raise GarminConnectTooManyRequestsError(
                     f"Rate limit exceeded: {e}"
                 ) from e
-            if status and 400 <= status < 500:
-                # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                new_exc = GarminConnectConnectionError(
-                    f"API client error ({status}): {e}"
-                )
-                new_exc.status_code = status  # type: ignore[attr-defined]
-                raise new_exc from e
+            # Re-raise original so .response / existing attributes survive.
+            raise
+        except HTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            logger.exception(
+                "API call failed for path '%s': %s (status=%s)", path, e, status
+            )
+            if status == 401:
+                raise GarminConnectAuthenticationError(
+                    f"Authentication failed: {e}"
+                ) from e
+            if status == 429:
+                raise GarminConnectTooManyRequestsError(
+                    f"Rate limit exceeded: {e}"
+                ) from e
             new_exc = GarminConnectConnectionError(f"HTTP error: {e}")
-            if status is not None:
-                new_exc.status_code = status  # type: ignore[attr-defined]
+            # Preserve response so callers can still introspect .response.status_code.
+            if getattr(e, "response", None) is not None:
+                new_exc.response = e.response  # type: ignore[attr-defined]
             raise new_exc from e
-        except Exception as e:
-            logger.exception("Connection error during connectapi path=%s", path)
+        except (requests.ConnectionError, requests.Timeout) as e:
+            logger.exception("Network error during connectapi path=%s", path)
             raise GarminConnectConnectionError(f"Connection error: {e}") from e
 
     def connectwebproxy(self, path: str, **kwargs: Any) -> Any:
@@ -497,7 +532,12 @@ class Garmin:
         )
 
     def _connectwebproxy_once(self, path: str, **kwargs: Any) -> Any:
-        """Single (non-retried) web proxy call with error translation."""
+        """Single (non-retried) web proxy call with error translation.
+
+        Translates auth (401) / rate-limit (429) to the dedicated exception
+        types. Other ``GarminConnectConnectionError`` instances propagate
+        unchanged so ``.response`` and any attached attributes survive.
+        """
         try:
             return self.client.request("GET", "connect", path, **kwargs).json()
         except GarminConnectConnectionError as e:
@@ -515,18 +555,10 @@ class Garmin:
                 raise GarminConnectTooManyRequestsError(
                     f"Web proxy rate limit: {e}"
                 ) from e
-            if status and 400 <= status < 500:
-                new_exc = GarminConnectConnectionError(
-                    f"Web proxy client error ({status}): {e}"
-                )
-                new_exc.status_code = status  # type: ignore[attr-defined]
-                raise new_exc from e
-            new_exc = GarminConnectConnectionError(f"Web proxy error: {e}")
-            if status is not None:
-                new_exc.status_code = status  # type: ignore[attr-defined]
-            raise new_exc from e
-        except Exception as e:
-            logger.exception("Connection error during web proxy path=%s", path)
+            # Re-raise original so .response / attributes survive.
+            raise
+        except (requests.ConnectionError, requests.Timeout) as e:
+            logger.exception("Network error during web proxy path=%s", path)
             raise GarminConnectConnectionError(f"Connection error: {e}") from e
 
     def download(self, path: str, **kwargs: Any) -> Any:
@@ -536,34 +568,37 @@ class Garmin:
         )
 
     def _download_once(self, path: str, **kwargs: Any) -> Any:
-        """Single (non-retried) download call with error translation."""
+        """Single (non-retried) download call with error translation.
+
+        Translates auth (401) / rate-limit (429) to the dedicated exception
+        types. Other ``GarminConnectConnectionError`` instances propagate
+        unchanged so callers retain access to ``.response`` and any attached
+        attributes.
+        """
         try:
             return self.client.download(path, **kwargs)
-        except (HTTPError, GarminConnectConnectionError) as e:
-            # For GarminConnectConnectionError, extract status from the wrapped HTTPError
-            if isinstance(e, GarminConnectConnectionError):
-                status = _extract_status_code(e)
-            else:
-                status = getattr(getattr(e, "response", None), "status_code", None)
-
+        except GarminConnectConnectionError as e:
+            status = _extract_status_code(e)
             logger.exception("Download failed for path '%s' (status=%s)", path, status)
             if status == 401:
                 raise GarminConnectAuthenticationError(f"Download error: {e}") from e
             if status == 429:
                 raise GarminConnectTooManyRequestsError(f"Download error: {e}") from e
-            if status and 400 <= status < 500:
-                # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                new_exc = GarminConnectConnectionError(
-                    f"Download client error ({status}): {e}"
-                )
-                new_exc.status_code = status  # type: ignore[attr-defined]
-                raise new_exc from e
+            # Re-raise original so .response / attributes survive.
+            raise
+        except HTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            logger.exception("Download failed for path '%s' (status=%s)", path, status)
+            if status == 401:
+                raise GarminConnectAuthenticationError(f"Download error: {e}") from e
+            if status == 429:
+                raise GarminConnectTooManyRequestsError(f"Download error: {e}") from e
             new_exc = GarminConnectConnectionError(f"Download error: {e}")
-            if status is not None:
-                new_exc.status_code = status  # type: ignore[attr-defined]
+            if getattr(e, "response", None) is not None:
+                new_exc.response = e.response  # type: ignore[attr-defined]
             raise new_exc from e
-        except Exception as e:
-            logger.exception("Download failed for path '%s'", path)
+        except (requests.ConnectionError, requests.Timeout) as e:
+            logger.exception("Network error during download path=%s", path)
             raise GarminConnectConnectionError(f"Download error: {e}") from e
 
     def login(self, /, tokenstore: str | None = None) -> tuple[str | None, str | None]:

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -14,9 +14,22 @@ from typing import Any
 
 import requests
 from requests import HTTPError
+from tenacity import (
+    Retrying,
+    before_sleep_log,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from . import client
 from .fit import FitEncoderWeight  # type: ignore
+
+# Regex used to extract an HTTP status code from the client's error messages.
+# The underlying client raises GarminConnectConnectionError with a message of
+# the form "API Error {status} - {detail}", so we parse it to decide whether
+# a failure is retryable (5xx) or not (4xx, auth, etc.).
+_STATUS_CODE_RE = re.compile(r"(?:API Error|Error|HTTP)\s*(\d{3})")
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +111,61 @@ def _validate_json_exists(response: requests.Response) -> dict[str, Any] | None:
     return response.json()
 
 
+def _extract_status_code(exc: BaseException) -> int | None:
+    """Best-effort extraction of an HTTP status code from an exception.
+
+    Checks a ``status_code`` attribute, then a ``response.status_code``
+    attribute, and finally parses common status-code patterns out of the
+    exception message (the client raises ``GarminConnectConnectionError``
+    with messages like ``"API Error 503 - ..."``).
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+
+    resp = getattr(exc, "response", None)
+    status = getattr(resp, "status_code", None)
+    if isinstance(status, int):
+        return status
+
+    match = _STATUS_CODE_RE.search(str(exc))
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    """Return True for transient errors worth retrying.
+
+    Retries:
+    - ``GarminConnectConnectionError`` with a 5xx status (server errors).
+    - ``GarminConnectConnectionError`` with no detectable status (network /
+      connection failures where the request never got a response).
+    - Raw ``requests`` network errors (connection / timeout) from lower
+      layers that escape without being wrapped.
+
+    Does NOT retry:
+    - ``GarminConnectAuthenticationError`` (401 — user must re-login).
+    - ``GarminConnectTooManyRequestsError`` (429 — caller should back off).
+    - Any error with a 4xx status code.
+    """
+    # Never retry auth failures or rate-limit errors.
+    if isinstance(
+        exc, (GarminConnectAuthenticationError, GarminConnectTooManyRequestsError)
+    ):
+        return False
+
+    if isinstance(exc, GarminConnectConnectionError):
+        status = _extract_status_code(exc)
+        if status is None:
+            # Network error / no response — treat as transient.
+            return True
+        return 500 <= status < 600
+
+    # Raw network errors from requests that somehow escaped the wrappers.
+    return isinstance(exc, (requests.ConnectionError, requests.Timeout))
+
+
 class Garmin:
     """Class for fetching data from Garmin Connect."""
 
@@ -108,8 +176,20 @@ class Garmin:
         is_cn: bool = False,
         prompt_mfa: Callable[[], str] | None = None,
         return_on_mfa: bool = False,
+        max_retries: int = 3,
+        retry_min_wait: float = 1.0,
+        retry_max_wait: float = 10.0,
     ) -> None:
-        """Create a new class instance."""
+        """Create a new class instance.
+
+        :param max_retries: Number of retries for transient network / 5xx
+            errors on ``connectapi``, ``connectwebproxy`` and ``download``.
+            Set to ``0`` to disable retries entirely. Defaults to ``3``.
+        :param retry_min_wait: Initial backoff in seconds between retries
+            (exponential with jitter). Defaults to ``1.0``.
+        :param retry_max_wait: Upper bound on the backoff in seconds between
+            retries. Defaults to ``10.0``.
+        """
         # Validate input types
         if email is not None and not isinstance(email, str):
             raise ValueError("email must be a string or None")
@@ -119,12 +199,29 @@ class Garmin:
             raise ValueError("is_cn must be a boolean")
         if not isinstance(return_on_mfa, bool):
             raise ValueError("return_on_mfa must be a boolean")
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int):
+            raise ValueError("max_retries must be an integer")
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        if isinstance(retry_min_wait, bool) or not isinstance(
+            retry_min_wait, (int, float)
+        ):
+            raise ValueError("retry_min_wait must be a number")
+        if isinstance(retry_max_wait, bool) or not isinstance(
+            retry_max_wait, (int, float)
+        ):
+            raise ValueError("retry_max_wait must be a number")
+        if retry_min_wait < 0 or retry_max_wait < 0:
+            raise ValueError("retry waits must be non-negative")
 
         self.username = email
         self.password = password
         self.is_cn = is_cn
         self.prompt_mfa = prompt_mfa
         self.return_on_mfa = return_on_mfa
+        self.max_retries = max_retries
+        self.retry_min_wait = float(retry_min_wait)
+        self.retry_max_wait = float(retry_max_wait)
 
         self.garmin_connect_user_settings_url = (
             "/userprofile-service/userprofile/user-settings"
@@ -321,15 +418,47 @@ class Garmin:
         self.full_name = None
         self.unit_system = None
 
+    def _retry_wrapper(self, func: Callable[[], Any], op: str, path: str) -> Any:
+        """Invoke ``func`` with exponential-backoff retries for transient errors.
+
+        Retries only when ``_is_retryable_error`` returns True (5xx server
+        errors and bare network failures). 4xx, auth and rate-limit errors
+        propagate immediately. Uses ``reraise=True`` so the original
+        exception is preserved for callers.
+        """
+        if self.max_retries <= 0:
+            return func()
+
+        retrying = Retrying(
+            stop=stop_after_attempt(self.max_retries + 1),
+            wait=wait_exponential_jitter(
+                initial=self.retry_min_wait, max=self.retry_max_wait
+            ),
+            retry=retry_if_exception(_is_retryable_error),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+        for attempt in retrying:
+            with attempt:
+                return func()
+        # Unreachable — Retrying either returns a value or reraises.
+        raise RuntimeError(f"{op} {path}: retry loop exited without a result")
+
     def connectapi(self, path: str, **kwargs: Any) -> Any:
-        """Wrapper for native connectapi with error handling."""
+        """Wrapper for native connectapi with error handling and retries."""
+        return self._retry_wrapper(
+            lambda: self._connectapi_once(path, **kwargs), "connectapi", path
+        )
+
+    def _connectapi_once(self, path: str, **kwargs: Any) -> Any:
+        """Single (non-retried) connectapi call with error translation."""
         try:
             return self.client.connectapi(path, **kwargs)
 
         except (HTTPError, GarminConnectConnectionError) as e:
             # For GarminConnectConnectionError, extract status from the wrapped HTTPError
             if isinstance(e, GarminConnectConnectionError):
-                status = getattr(getattr(e, "response", None), "status_code", None)
+                status = _extract_status_code(e)
             else:
                 status = getattr(getattr(e, "response", None), "status_code", None)
 
@@ -346,20 +475,33 @@ class Garmin:
                 ) from e
             if status and 400 <= status < 500:
                 # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                raise GarminConnectConnectionError(
+                new_exc = GarminConnectConnectionError(
                     f"API client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"HTTP error: {e}") from e
+                )
+                new_exc.status_code = status  # type: ignore[attr-defined]
+                raise new_exc from e
+            new_exc = GarminConnectConnectionError(f"HTTP error: {e}")
+            if status is not None:
+                new_exc.status_code = status  # type: ignore[attr-defined]
+            raise new_exc from e
         except Exception as e:
             logger.exception("Connection error during connectapi path=%s", path)
             raise GarminConnectConnectionError(f"Connection error: {e}") from e
 
     def connectwebproxy(self, path: str, **kwargs: Any) -> Any:
-        """Wrapper for web proxy requests to connect.garmin.com with error handling."""
+        """Wrapper for web proxy requests with error handling and retries."""
+        return self._retry_wrapper(
+            lambda: self._connectwebproxy_once(path, **kwargs),
+            "connectwebproxy",
+            path,
+        )
+
+    def _connectwebproxy_once(self, path: str, **kwargs: Any) -> Any:
+        """Single (non-retried) web proxy call with error translation."""
         try:
             return self.client.request("GET", "connect", path, **kwargs).json()
         except GarminConnectConnectionError as e:
-            status = getattr(getattr(e, "response", None), "status_code", None)
+            status = _extract_status_code(e)
             logger.exception(
                 "API call failed for web proxy path '%s' (status=%s)",
                 path,
@@ -374,22 +516,33 @@ class Garmin:
                     f"Web proxy rate limit: {e}"
                 ) from e
             if status and 400 <= status < 500:
-                raise GarminConnectConnectionError(
+                new_exc = GarminConnectConnectionError(
                     f"Web proxy client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"Web proxy error: {e}") from e
+                )
+                new_exc.status_code = status  # type: ignore[attr-defined]
+                raise new_exc from e
+            new_exc = GarminConnectConnectionError(f"Web proxy error: {e}")
+            if status is not None:
+                new_exc.status_code = status  # type: ignore[attr-defined]
+            raise new_exc from e
         except Exception as e:
             logger.exception("Connection error during web proxy path=%s", path)
             raise GarminConnectConnectionError(f"Connection error: {e}") from e
 
     def download(self, path: str, **kwargs: Any) -> Any:
-        """Wrapper for native download with error handling."""
+        """Wrapper for native download with error handling and retries."""
+        return self._retry_wrapper(
+            lambda: self._download_once(path, **kwargs), "download", path
+        )
+
+    def _download_once(self, path: str, **kwargs: Any) -> Any:
+        """Single (non-retried) download call with error translation."""
         try:
             return self.client.download(path, **kwargs)
         except (HTTPError, GarminConnectConnectionError) as e:
             # For GarminConnectConnectionError, extract status from the wrapped HTTPError
             if isinstance(e, GarminConnectConnectionError):
-                status = getattr(getattr(e, "response", None), "status_code", None)
+                status = _extract_status_code(e)
             else:
                 status = getattr(getattr(e, "response", None), "status_code", None)
 
@@ -400,10 +553,15 @@ class Garmin:
                 raise GarminConnectTooManyRequestsError(f"Download error: {e}") from e
             if status and 400 <= status < 500:
                 # Client errors (400-499) - API endpoint issues, bad parameters, etc.
-                raise GarminConnectConnectionError(
+                new_exc = GarminConnectConnectionError(
                     f"Download client error ({status}): {e}"
-                ) from e
-            raise GarminConnectConnectionError(f"Download error: {e}") from e
+                )
+                new_exc.status_code = status  # type: ignore[attr-defined]
+                raise new_exc from e
+            new_exc = GarminConnectConnectionError(f"Download error: {e}")
+            if status is not None:
+                new_exc.status_code = status  # type: ignore[attr-defined]
+            raise new_exc from e
         except Exception as e:
             logger.exception("Download failed for path '%s'", path)
             raise GarminConnectConnectionError(f"Download error: {e}") from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "curl_cffi>=0.6",
     "requests>=2.28",
+    "tenacity>=8.2",
     "ua-generator>=1.0",
 ]
 readme = "README.md"
@@ -71,6 +72,7 @@ linting = [
 testing = [
     "coverage",
     "pytest",
+    "pytest-mock>=3.10",
     "pytest-vcr>=1.0.2",
     "vcrpy>=7.0.0",
 ]
@@ -240,6 +242,7 @@ linting = [
 testing = [
     "coverage",
     "pytest",
+    "pytest-mock>=3.10",
     "pytest-vcr>=1.0.2",
     "vcrpy>=7.0.0",
 ]

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 import garminconnect
 from garminconnect import (
@@ -202,18 +203,18 @@ def test_request_reload(garmin: garminconnect.Garmin) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _fast_garmin(**kwargs: object) -> garminconnect.Garmin:
+def _fast_garmin(**kwargs):
     """Build a Garmin instance with near-zero retry waits for fast tests."""
     return garminconnect.Garmin(
         "email@example.org",
         "password",
         retry_min_wait=0.0,
         retry_max_wait=0.01,
-        **kwargs,  # type: ignore[arg-type]
+        **kwargs,
     )
 
 
-def test_connectapi_retries_on_503_then_succeeds(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_retries_on_503_then_succeeds(mocker):
     """503 -> 503 -> 200: connectapi should eventually return the good payload."""
     g = _fast_garmin(max_retries=3)
     good_payload = {"calendarDate": "2023-07-01", "totalSteps": 12345}
@@ -233,7 +234,7 @@ def test_connectapi_retries_on_503_then_succeeds(mocker: "pytest_mock.MockerFixt
     assert inner.call_count == 3
 
 
-def test_connectapi_does_not_retry_on_404(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_does_not_retry_on_404(mocker):
     """4xx failures must fail fast — one call only, no retries."""
     g = _fast_garmin(max_retries=3)
 
@@ -249,7 +250,7 @@ def test_connectapi_does_not_retry_on_404(mocker: "pytest_mock.MockerFixture") -
     assert inner.call_count == 1
 
 
-def test_connectapi_does_not_retry_on_401(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_does_not_retry_on_401(mocker):
     """401 auth errors must fail fast — user has to re-login."""
     g = _fast_garmin(max_retries=3)
 
@@ -265,7 +266,7 @@ def test_connectapi_does_not_retry_on_401(mocker: "pytest_mock.MockerFixture") -
     assert inner.call_count == 1
 
 
-def test_connectapi_does_not_retry_on_429(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_does_not_retry_on_429(mocker):
     """429 rate-limit errors are already a signal to back off — don't retry."""
     g = _fast_garmin(max_retries=3)
 
@@ -281,7 +282,7 @@ def test_connectapi_does_not_retry_on_429(mocker: "pytest_mock.MockerFixture") -
     assert inner.call_count == 1
 
 
-def test_connectapi_exhausts_retries_and_reraises(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_exhausts_retries_and_reraises(mocker):
     """After max_retries transient failures, the final 5xx error is re-raised."""
     g = _fast_garmin(max_retries=2)
 
@@ -298,7 +299,7 @@ def test_connectapi_exhausts_retries_and_reraises(mocker: "pytest_mock.MockerFix
     assert inner.call_count == 3
 
 
-def test_connectapi_retries_disabled(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectapi_retries_disabled(mocker):
     """max_retries=0 should disable retries entirely."""
     g = _fast_garmin(max_retries=0)
 
@@ -314,7 +315,7 @@ def test_connectapi_retries_disabled(mocker: "pytest_mock.MockerFixture") -> Non
     assert inner.call_count == 1
 
 
-def test_download_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_download_retries_on_5xx(mocker):
     """The download method should use the same retry wrapper."""
     g = _fast_garmin(max_retries=3)
     blob = b"fit-file-bytes"
@@ -333,12 +334,12 @@ def test_download_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> None:  
     assert inner.call_count == 2
 
 
-def test_connectwebproxy_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+def test_connectwebproxy_retries_on_5xx(mocker):
     """The connectwebproxy method should also be retried on 5xx."""
     g = _fast_garmin(max_retries=3)
 
     class _Resp:
-        def json(self) -> dict[str, int]:
+        def json(self):
             return {"ok": 1}
 
     inner = mocker.patch.object(
@@ -355,9 +356,116 @@ def test_connectwebproxy_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> 
     assert inner.call_count == 2
 
 
-def test_retry_invalid_max_retries() -> None:
+def test_retry_invalid_max_retries():
     """max_retries must be a non-negative int."""
     with pytest.raises(ValueError, match="max_retries"):
         garminconnect.Garmin("e@x.y", "p", max_retries=-1)
     with pytest.raises(ValueError, match="max_retries"):
         garminconnect.Garmin("e@x.y", "p", max_retries="3")  # type: ignore[arg-type]
+
+
+def test_connectapi_retries_on_raw_requests_connection_error(mocker):
+    """Raw requests.ConnectionError from lower layers should trigger retry."""
+    g = _fast_garmin(max_retries=3)
+    good_payload = {"ok": True}
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=[
+            requests.ConnectionError("DNS resolution failed"),
+            good_payload,
+        ],
+    )
+
+    result = g.connectapi("/some/path")
+    assert result == good_payload
+    assert inner.call_count == 2
+
+
+def test_connectapi_retries_on_raw_requests_timeout(mocker):
+    """Raw requests.Timeout from lower layers should trigger retry."""
+    g = _fast_garmin(max_retries=3)
+    good_payload = {"ok": True}
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=[
+            requests.Timeout("read timed out"),
+            good_payload,
+        ],
+    )
+
+    result = g.connectapi("/some/path")
+    assert result == good_payload
+    assert inner.call_count == 2
+
+
+def test_download_retries_on_raw_requests_connection_error(mocker):
+    """download() should retry raw requests.ConnectionError too."""
+    g = _fast_garmin(max_retries=3)
+
+    inner = mocker.patch.object(
+        g.client,
+        "download",
+        side_effect=[
+            requests.ConnectionError("connection reset"),
+            b"bytes",
+        ],
+    )
+
+    assert g.download("/download/path") == b"bytes"
+    assert inner.call_count == 2
+
+
+def test_connectapi_does_not_retry_statusless_without_network_cause(mocker):
+    """Status-less GarminConnectConnectionError without a network cause
+    (e.g. JSON decode error, AttributeError wrapped downstream) must NOT
+    be retried — it's a deterministic failure, retrying wastes time."""
+    g = _fast_garmin(max_retries=3)
+
+    # A fresh GarminConnectConnectionError with no status in the message
+    # and no __cause__ — represents a programming / decode bug.
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("Unexpected payload shape"),
+    )
+
+    with pytest.raises(GarminConnectConnectionError):
+        g.connectapi("/some/path")
+
+    assert inner.call_count == 1
+
+
+def test_get_gear_stats_404_returns_empty_dict(mocker):
+    """get_gear_stats() relies on being able to read e.response.status_code
+    after a 404 — our retry wrapper must not strip that attribute."""
+    g = _fast_garmin(max_retries=0)
+
+    # Fabricate a GarminConnectConnectionError that carries a .response
+    # attribute — simulating what a lower layer might attach.
+    resp = mocker.Mock()
+    resp.status_code = 404
+    err = GarminConnectConnectionError("API Error 404 - Not Found")
+    err.response = resp  # type: ignore[attr-defined]
+
+    mocker.patch.object(g.client, "connectapi", side_effect=err)
+
+    # Should swallow the 404 and return {} rather than propagating.
+    assert g.get_gear_stats("gear-uuid-abc") == {}
+
+
+def test_get_gear_activities_404_returns_empty_list(mocker):
+    """get_gear_activities() must also retain e.response.status_code access."""
+    g = _fast_garmin(max_retries=0)
+
+    resp = mocker.Mock()
+    resp.status_code = 404
+    err = GarminConnectConnectionError("API Error 404 - Not Found")
+    err.response = resp  # type: ignore[attr-defined]
+
+    mocker.patch.object(g.client, "connectapi", side_effect=err)
+
+    assert g.get_gear_activities("gear-uuid-abc") == []

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,6 +1,11 @@
 import pytest
 
 import garminconnect
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
 
 DATE = "2023-07-01"
 
@@ -190,3 +195,169 @@ def test_request_reload(garmin: garminconnect.Garmin) -> None:
     # Get steps data after reload - should still be accessible
     final_steps = sum(steps["steps"] for steps in garmin.get_steps_data(cdate))
     assert final_steps >= 0  # Steps data should be non-negative
+
+
+# ---------------------------------------------------------------------------
+# Retry / backoff tests (no network, no VCR cassettes).
+# ---------------------------------------------------------------------------
+
+
+def _fast_garmin(**kwargs: object) -> garminconnect.Garmin:
+    """Build a Garmin instance with near-zero retry waits for fast tests."""
+    return garminconnect.Garmin(
+        "email@example.org",
+        "password",
+        retry_min_wait=0.0,
+        retry_max_wait=0.01,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_connectapi_retries_on_503_then_succeeds(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """503 -> 503 -> 200: connectapi should eventually return the good payload."""
+    g = _fast_garmin(max_retries=3)
+    good_payload = {"calendarDate": "2023-07-01", "totalSteps": 12345}
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=[
+            GarminConnectConnectionError("API Error 503 - Service Unavailable"),
+            GarminConnectConnectionError("API Error 503 - Service Unavailable"),
+            good_payload,
+        ],
+    )
+
+    result = g.connectapi("/usersummary-service/usersummary/daily/2023-07-01")
+    assert result == good_payload
+    assert inner.call_count == 3
+
+
+def test_connectapi_does_not_retry_on_404(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """4xx failures must fail fast — one call only, no retries."""
+    g = _fast_garmin(max_retries=3)
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("API Error 404 - Not Found"),
+    )
+
+    with pytest.raises(GarminConnectConnectionError):
+        g.connectapi("/does/not/exist")
+
+    assert inner.call_count == 1
+
+
+def test_connectapi_does_not_retry_on_401(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """401 auth errors must fail fast — user has to re-login."""
+    g = _fast_garmin(max_retries=3)
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("API Error 401 - Unauthorized"),
+    )
+
+    with pytest.raises(GarminConnectAuthenticationError):
+        g.connectapi("/userprofile-service/userprofile/settings")
+
+    assert inner.call_count == 1
+
+
+def test_connectapi_does_not_retry_on_429(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """429 rate-limit errors are already a signal to back off — don't retry."""
+    g = _fast_garmin(max_retries=3)
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("API Error 429 - Too Many Requests"),
+    )
+
+    with pytest.raises(GarminConnectTooManyRequestsError):
+        g.connectapi("/usersummary-service/usersummary/daily/2023-07-01")
+
+    assert inner.call_count == 1
+
+
+def test_connectapi_exhausts_retries_and_reraises(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """After max_retries transient failures, the final 5xx error is re-raised."""
+    g = _fast_garmin(max_retries=2)
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("API Error 502 - Bad Gateway"),
+    )
+
+    with pytest.raises(GarminConnectConnectionError):
+        g.connectapi("/usersummary-service/usersummary/daily/2023-07-01")
+
+    # 1 initial attempt + 2 retries == 3 total calls
+    assert inner.call_count == 3
+
+
+def test_connectapi_retries_disabled(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """max_retries=0 should disable retries entirely."""
+    g = _fast_garmin(max_retries=0)
+
+    inner = mocker.patch.object(
+        g.client,
+        "connectapi",
+        side_effect=GarminConnectConnectionError("API Error 503 - Service Unavailable"),
+    )
+
+    with pytest.raises(GarminConnectConnectionError):
+        g.connectapi("/usersummary-service/usersummary/daily/2023-07-01")
+
+    assert inner.call_count == 1
+
+
+def test_download_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """The download method should use the same retry wrapper."""
+    g = _fast_garmin(max_retries=3)
+    blob = b"fit-file-bytes"
+
+    inner = mocker.patch.object(
+        g.client,
+        "download",
+        side_effect=[
+            GarminConnectConnectionError("API Error 500 - Internal Server Error"),
+            blob,
+        ],
+    )
+
+    result = g.download("/download-service/files/activity/12345")
+    assert result == blob
+    assert inner.call_count == 2
+
+
+def test_connectwebproxy_retries_on_5xx(mocker: "pytest_mock.MockerFixture") -> None:  # noqa: F821
+    """The connectwebproxy method should also be retried on 5xx."""
+    g = _fast_garmin(max_retries=3)
+
+    class _Resp:
+        def json(self) -> dict[str, int]:
+            return {"ok": 1}
+
+    inner = mocker.patch.object(
+        g.client,
+        "request",
+        side_effect=[
+            GarminConnectConnectionError("API Error 503 - Service Unavailable"),
+            _Resp(),
+        ],
+    )
+
+    result = g.connectwebproxy("/proxy/path")
+    assert result == {"ok": 1}
+    assert inner.call_count == 2
+
+
+def test_retry_invalid_max_retries() -> None:
+    """max_retries must be a non-negative int."""
+    with pytest.raises(ValueError, match="max_retries"):
+        garminconnect.Garmin("e@x.y", "p", max_retries=-1)
+    with pytest.raises(ValueError, match="max_retries"):
+        garminconnect.Garmin("e@x.y", "p", max_retries="3")  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

Garmin Connect is fronted by Cloudflare and fairly regularly returns transient 5xx responses or just drops connections. The library has no retry logic anywhere, so any flaky call surfaces straight up to the caller.

I found this while running nightly Garmin syncs — random 503s were breaking 365-day backfills with no recovery. One bad request in a 365-call loop and the whole backfill collapses, which is annoying enough that I figured it was worth a PR.

## What this changes

`connectapi`, `connectwebproxy` and `download` are now wrapped in a `tenacity.Retrying` loop that does exponential backoff with jitter.

Retries fire on:
- `GarminConnectConnectionError` with a 5xx status (parsed from the error message, since that's how the underlying client exposes it)
- `GarminConnectConnectionError` with no detectable status (pure network/connection failures — no response came back)
- Raw `requests.ConnectionError` / `requests.Timeout` if they somehow escape the lower layers

Explicitly **not** retried (these fail fast on the first attempt, same as today):
- `GarminConnectAuthenticationError` (401) — user has to re-login
- `GarminConnectTooManyRequestsError` (429) — already means "back off", retrying tighter would be wrong
- Any 4xx (403 / 404 / 409 / etc.) — these are client errors, retrying won't change anything

## New constructor parameters

```python
Garmin(
    email,
    password,
    ...,
    max_retries: int = 3,         # 0 to disable, default 3
    retry_min_wait: float = 1.0,  # initial backoff in seconds
    retry_max_wait: float = 10.0, # cap on backoff in seconds
)
```

Each retry attempt is logged at `WARNING` via `tenacity.before_sleep_log` so users running batch jobs can see what's happening.

## Backward compatibility

Fully backward compatible. The default (`max_retries=3`) just quietly makes things more reliable for everyone. Anyone who wants the old behaviour can pass `max_retries=0` and nothing changes.

The existing error-translation logic (401 -> `GarminConnectAuthenticationError`, 429 -> `GarminConnectTooManyRequestsError`, etc.) is untouched — the retry wrapper sits outside of it and only decides whether to call it again.

## Dependencies

- Adds `tenacity>=8.2` to core deps
- Adds `pytest-mock>=3.10` to the `testing` extra

## Tests

Adds 9 new tests in `tests/test_garmin.py` (no network, no VCR cassettes — they use `pytest-mock` to patch the client):
- 503 -> 503 -> 200 eventually succeeds
- 404 fails fast, one call only
- 401 fails fast as `GarminConnectAuthenticationError`
- 429 fails fast as `GarminConnectTooManyRequestsError`
- Exhausts retries and re-raises the final 5xx
- `max_retries=0` disables retries entirely
- `download` method uses the same retry wrapper (500 -> success)
- `connectwebproxy` method uses the same retry wrapper (503 -> success)
- Constructor rejects invalid `max_retries` values

All 17 existing VCR-backed tests still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic retries with exponential backoff for transient network failures.
* **Bug Fixes**
  * Improved error handling so authentication and rate-limit errors are not retried; preserved HTTP response info for callers.
* **Tests**
  * Added extensive unit tests covering retry/backoff behavior, non-retryable cases, and validation of retry settings.
* **Chores**
  * Added runtime and testing dependencies required for the retry implementation and mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->