### PR TITLE
fix(workout): correct SwimmingWorkout sportTypeId to 4

### DIFF
--- a/garminconnect/workout.py
+++ b/garminconnect/workout.py
@@ -219,7 +219,9 @@ class SwimmingWorkout(BaseWorkout):
 
     sportType: dict[str, Any] = Field(
         default_factory=lambda: {
-            "sportTypeId": SportType.SWIMMING,
+            # Garmin workout-service expects swimming sportTypeId=4.
+            # Using 3 gets normalized to sportTypeKey="other" on upload.
+            "sportTypeId": 4,
             "sportTypeKey": "swimming",
             "displayOrder": 3,
         }

--- a/tests/test_workout_constants.py
+++ b/tests/test_workout_constants.py
@@ -3,7 +3,15 @@
 Prevents silent drift of constant values (see issue #333).
 """
 
-from garminconnect.workout import ConditionType, SportType, StepType, TargetType
+from garminconnect.workout import (
+    ConditionType,
+    SportType,
+    StepType,
+    SwimmingWorkout,
+    TargetType,
+    WorkoutSegment,
+    create_warmup_step,
+)
 
 
 def test_target_type_ids() -> None:
@@ -47,3 +55,21 @@ def test_sport_type_ids() -> None:
     assert SportType.FITNESS_EQUIPMENT == 6
     assert SportType.HIKING == 7
     assert SportType.OTHER == 8
+
+
+def test_swimming_workout_uses_expected_sport_type_id() -> None:
+    """Ensure typed swimming workouts upload as sportTypeKey=swimming."""
+    workout = SwimmingWorkout(
+        workoutName="Regression Swim",
+        estimatedDurationInSecs=300,
+        workoutSegments=[
+            WorkoutSegment(
+                segmentOrder=1,
+                sportType={"sportTypeId": 4, "sportTypeKey": "swimming"},
+                workoutSteps=[create_warmup_step(300.0)],
+            )
+        ],
+    )
+    payload = workout.to_dict()
+    assert payload["sportType"]["sportTypeId"] == 4
+    assert payload["sportType"]["sportTypeKey"] == "swimming"


### PR DESCRIPTION
## Summary
This fixes `SwimmingWorkout` typed uploads being normalized to `sportTypeKey=other` on Garmin Connect.

## Root cause
`SwimmingWorkout` currently uses `sportTypeId = 3`. On current Garmin workout-service catalogs (`GET /workout-service/workout/types`), swimming is `sportTypeId = 4`.

## Changes
- `garminconnect/workout.py`
  - `SwimmingWorkout` default `sportTypeId` changed from `3` to `4`.
- `tests/test_workout_constants.py`
  - Added regression test `test_swimming_workout_uses_expected_sport_type_id` to pin typed payload output to `sportTypeId=4` and `sportTypeKey=swimming`.

## Validation
- `pytest tests/test_workout_constants.py -q` passes.
- Real account verification: typed swim workout with `sportTypeId=3` was classified as `other`; with `4` it is correctly classified as `swimming`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected swimming workout sport type identifier to ensure accurate exercise tracking and system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->