### PR TITLE
feat(typed): add optional Pydantic namespace wrapper (#354)

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -12,7 +12,10 @@ from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .typed import TypedGarmin
 
 import requests
 from requests import HTTPError
@@ -507,6 +510,30 @@ class Garmin:
         self.display_name: str | None = None
         self.full_name: str | None = None
         self.unit_system: str | None = None
+
+    @functools.cached_property
+    def typed(self) -> "TypedGarmin":
+        """Return a typed namespace that wraps selected endpoints with Pydantic models.
+
+        Example::
+
+            g = Garmin(email, password)
+            g.login()
+            stats = g.typed.get_stats("2026-04-21")  # DailyStats
+
+        Requires the optional ``typed`` extra::
+
+            pip install 'garminconnect[typed]'
+
+        See :mod:`garminconnect.typed` for the list of wrapped endpoints and
+        response models. **Experimental** — shapes may change between minor
+        releases.
+        """
+        # Lazy import so pydantic stays an optional dep. The typed module
+        # raises a clear ImportError on its own if pydantic is missing.
+        from .typed import TypedGarmin
+
+        return TypedGarmin(self)
 
     @_handle_api_errors("API call")
     def connectapi(self, path: str, **kwargs: Any) -> Any:

--- a/garminconnect/typed.py
+++ b/garminconnect/typed.py
@@ -1,0 +1,588 @@
+"""Optional Pydantic response models for typed Garmin Connect API access.
+
+Experimental — model shapes and the ``g.typed`` surface may change between
+minor releases until the pattern stabilises. Pin a specific version if you
+depend on typed response shapes.
+
+The typed namespace wraps a small, curated set of high-value endpoints. All
+other endpoints remain available via the standard ``g.get_*()`` methods with
+``dict[str, Any]`` responses — this layer is purely additive.
+
+Usage:
+    from garminconnect import Garmin
+
+    g = Garmin(email, password)
+    g.login()
+
+    raw = g.get_stats("2026-04-21")           # dict[str, Any] — unchanged
+    stats = g.typed.get_stats("2026-04-21")   # DailyStats (Pydantic)
+    print(stats.total_steps, stats.resting_heart_rate)
+
+Install the optional dependency first::
+
+    pip install 'garminconnect[typed]'
+
+On validation failure, raises :class:`GarminConnectResponseValidationError`
+with the unvalidated response preserved as ``.raw`` so callers can still
+access the data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
+try:
+    from pydantic import BaseModel, ConfigDict, Field
+    from pydantic import ValidationError as _PydanticValidationError
+except ImportError as _exc:  # pragma: no cover - exercised via integration
+    raise ImportError(
+        "The `typed` namespace requires pydantic. Install it with:\n"
+        "    pip install 'garminconnect[typed]'"
+    ) from _exc
+
+_M = TypeVar("_M", bound=BaseModel)
+
+if TYPE_CHECKING:
+    from . import Garmin
+
+
+class GarminConnectResponseValidationError(Exception):
+    """Raised when a Garmin response fails Pydantic validation.
+
+    The unvalidated response is available as ``raw`` so callers can still
+    inspect the data. The underlying :class:`pydantic.ValidationError` is
+    available as ``pydantic_error``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        raw: Any,
+        pydantic_error: _PydanticValidationError,
+    ) -> None:
+        super().__init__(message)
+        self.raw = raw
+        self.pydantic_error = pydantic_error
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+# ``extra='allow'`` is deliberate: Garmin occasionally adds fields with new
+# firmware / subscription tiers, and we don't want validation failures for
+# benign additions. ``populate_by_name=True`` lets callers construct models
+# using either the Python attribute name or the JSON alias, which is useful
+# for tests.
+_COMMON_CONFIG = ConfigDict(
+    extra="allow",
+    populate_by_name=True,
+)
+
+
+class _BaseResponse(BaseModel):
+    model_config = _COMMON_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Daily Stats (get_stats / get_user_summary)
+# ---------------------------------------------------------------------------
+
+
+class DailyStats(_BaseResponse):
+    """Daily summary returned by ``get_stats`` and ``get_user_summary``.
+
+    Only the most commonly consumed fields are modelled explicitly; additional
+    fields are accessible through ``model_extra`` or by dumping the model.
+    """
+
+    user_profile_id: int | None = Field(default=None, alias="userProfileId")
+    calendar_date: str | None = Field(default=None, alias="calendarDate")
+
+    total_steps: int | None = Field(default=None, alias="totalSteps")
+    daily_step_goal: int | None = Field(default=None, alias="dailyStepGoal")
+    total_distance_meters: float | None = Field(
+        default=None, alias="totalDistanceMeters"
+    )
+
+    total_kilocalories: float | None = Field(default=None, alias="totalKilocalories")
+    active_kilocalories: float | None = Field(default=None, alias="activeKilocalories")
+    bmr_kilocalories: float | None = Field(default=None, alias="bmrKilocalories")
+    wellness_kilocalories: float | None = Field(
+        default=None, alias="wellnessKilocalories"
+    )
+
+    min_heart_rate: int | None = Field(default=None, alias="minHeartRate")
+    max_heart_rate: int | None = Field(default=None, alias="maxHeartRate")
+    resting_heart_rate: int | None = Field(default=None, alias="restingHeartRate")
+
+    sleeping_seconds: int | None = Field(default=None, alias="sleepingSeconds")
+    sedentary_seconds: int | None = Field(default=None, alias="sedentarySeconds")
+    active_seconds: int | None = Field(default=None, alias="activeSeconds")
+    highly_active_seconds: int | None = Field(default=None, alias="highlyActiveSeconds")
+
+    moderate_intensity_minutes: int | None = Field(
+        default=None, alias="moderateIntensityMinutes"
+    )
+    vigorous_intensity_minutes: int | None = Field(
+        default=None, alias="vigorousIntensityMinutes"
+    )
+
+    floors_ascended: float | None = Field(default=None, alias="floorsAscended")
+    floors_descended: float | None = Field(default=None, alias="floorsDescended")
+
+    average_stress_level: int | None = Field(default=None, alias="averageStressLevel")
+    max_stress_level: int | None = Field(default=None, alias="maxStressLevel")
+    stress_duration: int | None = Field(default=None, alias="stressDuration")
+    rest_stress_duration: int | None = Field(default=None, alias="restStressDuration")
+
+    body_battery_charged_value: int | None = Field(
+        default=None, alias="bodyBatteryChargedValue"
+    )
+    body_battery_drained_value: int | None = Field(
+        default=None, alias="bodyBatteryDrainedValue"
+    )
+    body_battery_highest_value: int | None = Field(
+        default=None, alias="bodyBatteryHighestValue"
+    )
+    body_battery_lowest_value: int | None = Field(
+        default=None, alias="bodyBatteryLowestValue"
+    )
+
+    privacy_protected: bool | None = Field(default=None, alias="privacyProtected")
+
+
+# ---------------------------------------------------------------------------
+# Sleep (get_sleep_data)
+# ---------------------------------------------------------------------------
+
+
+class SleepScoreValue(_BaseResponse):
+    """One component of the Garmin sleep score breakdown (value + qualifier)."""
+
+    value: int | None = None
+    qualifier_key: str | None = Field(default=None, alias="qualifierKey")
+
+
+class SleepScores(_BaseResponse):
+    """Sub-scores that make up the overall nightly sleep score."""
+
+    overall: SleepScoreValue | None = None
+    total_duration: SleepScoreValue | None = Field(default=None, alias="totalDuration")
+    stress: SleepScoreValue | None = None
+    awake_count: SleepScoreValue | None = Field(default=None, alias="awakeCount")
+    rem_percentage: SleepScoreValue | None = Field(default=None, alias="remPercentage")
+    restlessness: SleepScoreValue | None = None
+    light_percentage: SleepScoreValue | None = Field(
+        default=None, alias="lightPercentage"
+    )
+    deep_percentage: SleepScoreValue | None = Field(
+        default=None, alias="deepPercentage"
+    )
+
+
+class DailySleepDTO(_BaseResponse):
+    """Nested sleep summary inside a :class:`SleepData` response."""
+
+    user_profile_pk: int | None = Field(default=None, alias="userProfilePK")
+    calendar_date: str | None = Field(default=None, alias="calendarDate")
+
+    sleep_time_seconds: int | None = Field(default=None, alias="sleepTimeSeconds")
+    nap_time_seconds: int | None = Field(default=None, alias="napTimeSeconds")
+    sleep_window_confirmed: bool | None = Field(
+        default=None, alias="sleepWindowConfirmed"
+    )
+
+    deep_sleep_seconds: int | None = Field(default=None, alias="deepSleepSeconds")
+    light_sleep_seconds: int | None = Field(default=None, alias="lightSleepSeconds")
+    rem_sleep_seconds: int | None = Field(default=None, alias="remSleepSeconds")
+    awake_sleep_seconds: int | None = Field(default=None, alias="awakeSleepSeconds")
+
+    sleep_start_timestamp_gmt: int | None = Field(
+        default=None, alias="sleepStartTimestampGMT"
+    )
+    sleep_end_timestamp_gmt: int | None = Field(
+        default=None, alias="sleepEndTimestampGMT"
+    )
+    sleep_start_timestamp_local: int | None = Field(
+        default=None, alias="sleepStartTimestampLocal"
+    )
+    sleep_end_timestamp_local: int | None = Field(
+        default=None, alias="sleepEndTimestampLocal"
+    )
+
+    avg_sleep_hrv: float | None = Field(default=None, alias="avgSleepHRV")
+    avg_spo2: float | None = Field(default=None, alias="avgSpO2")
+    avg_respiration_value: float | None = Field(
+        default=None, alias="avgRespirationValue"
+    )
+    lowest_respiration_value: float | None = Field(
+        default=None, alias="lowestRespirationValue"
+    )
+    highest_respiration_value: float | None = Field(
+        default=None, alias="highestRespirationValue"
+    )
+
+    sleep_scores: SleepScores | None = Field(default=None, alias="sleepScores")
+
+
+class SleepData(_BaseResponse):
+    """Response for ``get_sleep_data``.
+
+    The most useful summary lives under ``daily_sleep_dto``; callers that want
+    per-minute heart rate / movement / SpO2 arrays should use the raw dict via
+    ``g.get_sleep_data`` since those arrays are large and rarely needed in
+    typed form.
+    """
+
+    daily_sleep_dto: DailySleepDTO | None = Field(default=None, alias="dailySleepDTO")
+
+
+# ---------------------------------------------------------------------------
+# HRV (get_hrv_data)
+# ---------------------------------------------------------------------------
+
+
+class HrvBaseline(_BaseResponse):
+    """Personal HRV baseline ranges derived from the user's history."""
+
+    low_upper: float | None = Field(default=None, alias="lowUpper")
+    balanced_low: float | None = Field(default=None, alias="balancedLow")
+    balanced_upper: float | None = Field(default=None, alias="balancedUpper")
+    marker_value: float | None = Field(default=None, alias="markerValue")
+
+
+class HrvSummary(_BaseResponse):
+    """Summary of HRV stats (weekly / last-night averages, status, feedback)."""
+
+    calendar_date: str | None = Field(default=None, alias="calendarDate")
+    weekly_avg: float | None = Field(default=None, alias="weeklyAvg")
+    last_night_avg: float | None = Field(default=None, alias="lastNightAvg")
+    last_night_5_min_high: float | None = Field(default=None, alias="lastNight5MinHigh")
+    status: str | None = None
+    feedback_phrase: str | None = Field(default=None, alias="feedbackPhrase")
+    baseline: HrvBaseline | None = None
+
+
+class HrvData(_BaseResponse):
+    """Response for ``get_hrv_data``.
+
+    Note: ``get_hrv_data`` may return ``None`` if HRV data is not available for
+    the requested date. The typed wrapper preserves this — ``g.typed.get_hrv_data``
+    returns ``HrvData | None``.
+    """
+
+    user_profile_pk: int | None = Field(default=None, alias="userProfilePK")
+    hrv_summary: HrvSummary | None = Field(default=None, alias="hrvSummary")
+    hrv_readings: list[dict[str, Any]] | None = Field(default=None, alias="hrvReadings")
+    start_timestamp_gmt: str | None = Field(default=None, alias="startTimestampGMT")
+    end_timestamp_gmt: str | None = Field(default=None, alias="endTimestampGMT")
+    start_timestamp_local: str | None = Field(default=None, alias="startTimestampLocal")
+    end_timestamp_local: str | None = Field(default=None, alias="endTimestampLocal")
+    sleep_start_timestamp_gmt: str | None = Field(
+        default=None, alias="sleepStartTimestampGMT"
+    )
+    sleep_end_timestamp_gmt: str | None = Field(
+        default=None, alias="sleepEndTimestampGMT"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Body Battery (get_body_battery)
+# ---------------------------------------------------------------------------
+
+
+class BodyBatteryEntry(_BaseResponse):
+    """One entry from ``get_body_battery``.
+
+    ``get_body_battery`` always returns a list; for a single date the list has
+    one entry. ``body_battery_values_array`` is a list of ``[timestamp, level]``
+    pairs sampled throughout the day.
+    """
+
+    date: str | None = None
+    charged: int | None = None
+    drained: int | None = None
+    start_timestamp_gmt: str | None = Field(default=None, alias="startTimestampGMT")
+    end_timestamp_gmt: str | None = Field(default=None, alias="endTimestampGMT")
+    start_timestamp_local: str | None = Field(default=None, alias="startTimestampLocal")
+    end_timestamp_local: str | None = Field(default=None, alias="endTimestampLocal")
+    body_battery_values_array: list[list[Any]] | None = Field(
+        default=None, alias="bodyBatteryValuesArray"
+    )
+    body_battery_value_descriptors_dto_list: list[dict[str, Any]] | None = Field(
+        default=None, alias="bodyBatteryValueDescriptorDTOList"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Training Readiness (get_training_readiness)
+# ---------------------------------------------------------------------------
+
+
+class TrainingReadiness(_BaseResponse):
+    """One snapshot from ``get_training_readiness``.
+
+    The endpoint returns a list of snapshots — typically one per wake-up event
+    or scheduled update. Use the snapshot with the most recent ``timestamp``
+    for the current reading.
+
+    ``recovery_time`` is reported in **minutes**. When
+    ``recovery_time_change_phrase == 'REACHED_ZERO'`` the user is fully
+    recovered regardless of the numeric value (Garmin keeps the last assigned
+    value after the clock drains).
+    """
+
+    user_profile_pk: int | None = Field(default=None, alias="userProfilePK")
+    calendar_date: str | None = Field(default=None, alias="calendarDate")
+    timestamp: str | None = None
+    timestamp_local: str | None = Field(default=None, alias="timestampLocal")
+    device_id: int | None = Field(default=None, alias="deviceId")
+
+    score: int | None = None
+    level: str | None = None
+    feedback_long: str | None = Field(default=None, alias="feedbackLong")
+    feedback_short: str | None = Field(default=None, alias="feedbackShort")
+
+    sleep_score: int | None = Field(default=None, alias="sleepScore")
+    sleep_score_factor_percent: int | None = Field(
+        default=None, alias="sleepScoreFactorPercent"
+    )
+    sleep_score_factor_feedback: str | None = Field(
+        default=None, alias="sleepScoreFactorFeedback"
+    )
+
+    recovery_time: int | None = Field(default=None, alias="recoveryTime")
+    recovery_time_factor_percent: int | None = Field(
+        default=None, alias="recoveryTimeFactorPercent"
+    )
+    recovery_time_factor_feedback: str | None = Field(
+        default=None, alias="recoveryTimeFactorFeedback"
+    )
+    recovery_time_change_phrase: str | None = Field(
+        default=None, alias="recoveryTimeChangePhrase"
+    )
+
+    acwr_factor_percent: int | None = Field(default=None, alias="acwrFactorPercent")
+    acwr_factor_feedback: str | None = Field(default=None, alias="acwrFactorFeedback")
+
+    hrv_factor_percent: int | None = Field(default=None, alias="hrvFactorPercent")
+    hrv_factor_feedback: str | None = Field(default=None, alias="hrvFactorFeedback")
+
+    stress_history_factor_percent: int | None = Field(
+        default=None, alias="stressHistoryFactorPercent"
+    )
+    stress_history_factor_feedback: str | None = Field(
+        default=None, alias="stressHistoryFactorFeedback"
+    )
+
+    input_context: str | None = Field(default=None, alias="inputContext")
+
+
+# ---------------------------------------------------------------------------
+# Activity (get_activities_by_date)
+# ---------------------------------------------------------------------------
+
+
+class ActivityType(_BaseResponse):
+    """Garmin activity type classification (``typeKey`` is the main lookup)."""
+
+    type_id: int | None = Field(default=None, alias="typeId")
+    type_key: str | None = Field(default=None, alias="typeKey")
+    parent_type_id: int | None = Field(default=None, alias="parentTypeId")
+    is_hidden: bool | None = Field(default=None, alias="isHidden")
+
+
+class Activity(_BaseResponse):
+    """One activity from ``get_activities_by_date``.
+
+    Strength-training activities populate ``total_sets``, ``total_reps`` and
+    ``total_volume``; other activity types leave those fields as ``None``.
+    """
+
+    activity_id: int | None = Field(default=None, alias="activityId")
+    activity_name: str | None = Field(default=None, alias="activityName")
+
+    start_time_local: str | None = Field(default=None, alias="startTimeLocal")
+    start_time_gmt: str | None = Field(default=None, alias="startTimeGMT")
+
+    activity_type: ActivityType | None = Field(default=None, alias="activityType")
+
+    duration: float | None = None
+    moving_duration: float | None = Field(default=None, alias="movingDuration")
+    elapsed_duration: float | None = Field(default=None, alias="elapsedDuration")
+
+    distance: float | None = None
+    elevation_gain: float | None = Field(default=None, alias="elevationGain")
+    elevation_loss: float | None = Field(default=None, alias="elevationLoss")
+
+    average_speed: float | None = Field(default=None, alias="averageSpeed")
+    max_speed: float | None = Field(default=None, alias="maxSpeed")
+
+    average_hr: float | None = Field(default=None, alias="averageHR")
+    max_hr: float | None = Field(default=None, alias="maxHR")
+
+    calories: float | None = None
+    bmr_calories: float | None = Field(default=None, alias="bmrCalories")
+
+    avg_power: float | None = Field(default=None, alias="avgPower")
+    max_power: float | None = Field(default=None, alias="maxPower")
+    normalized_power: float | None = Field(default=None, alias="normPower")
+
+    aerobic_training_effect: float | None = Field(
+        default=None, alias="aerobicTrainingEffect"
+    )
+    anaerobic_training_effect: float | None = Field(
+        default=None, alias="anaerobicTrainingEffect"
+    )
+    activity_training_load: float | None = Field(
+        default=None, alias="activityTrainingLoad"
+    )
+    training_effect_label: str | None = Field(default=None, alias="trainingEffectLabel")
+
+    average_running_cadence: float | None = Field(
+        default=None, alias="averageRunningCadenceInStepsPerMinute"
+    )
+    max_running_cadence: float | None = Field(
+        default=None, alias="maxRunningCadenceInStepsPerMinute"
+    )
+
+    total_sets: int | None = Field(default=None, alias="totalSets")
+    active_sets: int | None = Field(default=None, alias="activeSets")
+    total_reps: int | None = Field(default=None, alias="totalReps")
+    total_volume: float | None = Field(default=None, alias="totalVolume")
+
+
+# ---------------------------------------------------------------------------
+# Wrapper
+# ---------------------------------------------------------------------------
+
+
+class TypedGarmin:
+    """Typed namespace accessor for a curated set of Garmin Connect endpoints.
+
+    Access via the :attr:`Garmin.typed` cached property, never instantiate
+    directly::
+
+        g = Garmin(email, password)
+        g.login()
+        stats = g.typed.get_stats("2026-04-21")
+
+    Each method is a thin wrapper around the corresponding ``Garmin`` method
+    that validates the response with a Pydantic model. On validation failure,
+    raises :class:`GarminConnectResponseValidationError` with the unvalidated
+    response available as ``.raw``.
+
+    **Experimental.** Model shapes and method signatures may change in future
+    releases; pin a specific version if you depend on them.
+    """
+
+    def __init__(self, garmin: Garmin) -> None:
+        self._garmin = garmin
+
+    @staticmethod
+    def _validate(model_cls: type[_M], raw: Any, method_name: str) -> _M:
+        try:
+            return model_cls.model_validate(raw)
+        except _PydanticValidationError as exc:
+            raise GarminConnectResponseValidationError(
+                f"Response from {method_name}() failed {model_cls.__name__} "
+                f"validation: {exc}",
+                raw=raw,
+                pydantic_error=exc,
+            ) from exc
+
+    # -- Daily stats ---------------------------------------------------------
+
+    def get_stats(self, cdate: str) -> DailyStats:
+        """Return daily stats for ``cdate`` as a :class:`DailyStats` model."""
+        raw = self._garmin.get_stats(cdate)
+        return self._validate(DailyStats, raw, "get_stats")
+
+    def get_user_summary(self, cdate: str) -> DailyStats:
+        """Return the user summary for ``cdate`` as a :class:`DailyStats` model."""
+        raw = self._garmin.get_user_summary(cdate)
+        return self._validate(DailyStats, raw, "get_user_summary")
+
+    # -- Sleep ---------------------------------------------------------------
+
+    def get_sleep_data(self, cdate: str) -> SleepData:
+        """Return sleep data for ``cdate`` as a :class:`SleepData` model."""
+        raw = self._garmin.get_sleep_data(cdate)
+        return self._validate(SleepData, raw, "get_sleep_data")
+
+    # -- HRV -----------------------------------------------------------------
+
+    def get_hrv_data(self, cdate: str) -> HrvData | None:
+        """Return HRV data for ``cdate`` as :class:`HrvData`, or ``None`` if absent."""
+        raw = self._garmin.get_hrv_data(cdate)
+        if raw is None:
+            return None
+        return self._validate(HrvData, raw, "get_hrv_data")
+
+    # -- Body battery --------------------------------------------------------
+
+    def get_body_battery(
+        self, startdate: str, enddate: str | None = None
+    ) -> list[BodyBatteryEntry]:
+        """Return body battery entries between ``startdate`` and ``enddate``."""
+        raw = self._garmin.get_body_battery(startdate, enddate)
+        if not isinstance(raw, list):
+            return []
+        return [
+            self._validate(BodyBatteryEntry, item, "get_body_battery") for item in raw
+        ]
+
+    # -- Training readiness --------------------------------------------------
+
+    def get_training_readiness(self, cdate: str) -> list[TrainingReadiness]:
+        """Return training readiness snapshots for ``cdate``.
+
+        Despite the underlying ``Garmin.get_training_readiness`` returning
+        ``dict[str, Any]`` in its type annotation, the live endpoint returns a
+        list of snapshots; this wrapper reflects the real shape.
+        """
+        raw = self._garmin.get_training_readiness(cdate)
+        if not isinstance(raw, list):
+            return []
+        return [
+            self._validate(TrainingReadiness, item, "get_training_readiness")
+            for item in raw
+        ]
+
+    # -- Activities ----------------------------------------------------------
+
+    def get_activities_by_date(
+        self,
+        startdate: str,
+        enddate: str | None = None,
+        activitytype: str | None = None,
+        sortorder: str | None = None,
+    ) -> list[Activity]:
+        """Return activities between two dates as a list of :class:`Activity`."""
+        raw = self._garmin.get_activities_by_date(
+            startdate, enddate, activitytype, sortorder
+        )
+        if not isinstance(raw, list):
+            return []
+        return [
+            self._validate(Activity, item, "get_activities_by_date") for item in raw
+        ]
+
+
+__all__ = [
+    "Activity",
+    "ActivityType",
+    "BodyBatteryEntry",
+    "DailySleepDTO",
+    "DailyStats",
+    "GarminConnectResponseValidationError",
+    "HrvBaseline",
+    "HrvData",
+    "HrvSummary",
+    "SleepData",
+    "SleepScoreValue",
+    "SleepScores",
+    "TrainingReadiness",
+    "TypedGarmin",
+]

--- a/garminconnect/typed.py
+++ b/garminconnect/typed.py
@@ -538,17 +538,21 @@ class TypedGarmin:
     def get_training_readiness(self, cdate: str) -> list[TrainingReadiness]:
         """Return training readiness snapshots for ``cdate``.
 
-        Despite the underlying ``Garmin.get_training_readiness`` returning
-        ``dict[str, Any]`` in its type annotation, the live endpoint returns a
-        list of snapshots; this wrapper reflects the real shape.
+        The underlying endpoint may return either a list of snapshots or a
+        single snapshot object depending on account/firmware behavior. This
+        wrapper normalizes both shapes to ``list[TrainingReadiness]``.
         """
         raw = self._garmin.get_training_readiness(cdate)
-        if not isinstance(raw, list):
-            return []
-        return [
-            self._validate(TrainingReadiness, item, "get_training_readiness")
-            for item in raw
-        ]
+        if isinstance(raw, list):
+            return [
+                self._validate(TrainingReadiness, item, "get_training_readiness")
+                for item in raw
+            ]
+        if isinstance(raw, dict):
+            return [
+                self._validate(TrainingReadiness, raw, "get_training_readiness")
+            ]
+        return []
 
     # -- Activities ----------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ dev = [
 workout = [
     "pydantic>=2.0.0",
 ]
+typed = [
+    "pydantic>=2.0.0",
+]
 linting = [
     "black[jupyter]",
     "ruff",

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -1,0 +1,390 @@
+"""Unit tests for the optional typed namespace wrapper.
+
+These tests cover the ``g.typed`` accessor introduced in the ``[typed]``
+extra: every wrapper method delegates to the underlying raw ``Garmin`` method
+and validates the response with a Pydantic model.
+
+The tests mock each raw method with canned payloads pulled from real Garmin
+responses (fields renamed / truncated so we don't commit a full user record)
+and assert:
+
+    * happy-path: the returned model exposes the expected attributes
+    * ``extra='allow'``: unknown fields round-trip into ``model_extra``
+      instead of failing validation
+    * missing fields: all modelled fields tolerate absence (default ``None``)
+    * validation errors: structural failures raise
+      ``GarminConnectResponseValidationError`` with ``.raw`` preserved
+    * list endpoints: empty / non-list responses return ``[]``
+    * ``get_hrv_data``: a ``None`` response passes through unchanged
+
+Run with::
+
+    python -m pytest tests/test_typed.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import garminconnect
+from garminconnect.typed import (
+    Activity,
+    BodyBatteryEntry,
+    DailyStats,
+    GarminConnectResponseValidationError,
+    HrvData,
+    SleepData,
+    TrainingReadiness,
+    TypedGarmin,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def garmin() -> garminconnect.Garmin:
+    """Return a Garmin instance with no network dependency."""
+    g = garminconnect.Garmin("test@example.com", "password")
+    g.display_name = "test-display"
+    g.full_name = "Test User"
+    return g
+
+
+# Sample payloads are deliberately small — just enough to exercise validation
+# and happy-path access. Real Garmin responses are much larger; the models are
+# permissive (``extra='allow'``) so extra fields are accepted silently.
+
+
+SAMPLE_DAILY_STATS: dict = {
+    "userProfileId": 12345,
+    "calendarDate": "2026-04-21",
+    "totalSteps": 8500,
+    "totalDistanceMeters": 6200.5,
+    "totalKilocalories": 2450.0,
+    "activeKilocalories": 700.0,
+    "restingHeartRate": 54,
+    "minHeartRate": 48,
+    "maxHeartRate": 142,
+    "highlyActiveSeconds": 1200,
+    "moderateIntensityMinutes": 22,
+    "vigorousIntensityMinutes": 4,
+    "bodyBatteryHighestValue": 92,
+    "bodyBatteryLowestValue": 38,
+    "averageStressLevel": 29,
+    "privacyProtected": False,
+}
+
+
+SAMPLE_SLEEP_DATA: dict = {
+    "dailySleepDTO": {
+        "userProfilePK": 12345,
+        "calendarDate": "2026-04-21",
+        "sleepTimeSeconds": 25200,
+        "napTimeSeconds": 0,
+        "deepSleepSeconds": 5400,
+        "lightSleepSeconds": 14400,
+        "remSleepSeconds": 4800,
+        "awakeSleepSeconds": 600,
+        "sleepStartTimestampGMT": 1761100200000,
+        "sleepEndTimestampGMT": 1761125400000,
+        "avgSleepHRV": 52.3,
+        "avgSpO2": 96.0,
+        "avgRespirationValue": 14.2,
+        "sleepScores": {
+            "overall": {"value": 84, "qualifierKey": "GOOD"},
+            "totalDuration": {"value": 90, "qualifierKey": "EXCELLENT"},
+        },
+    }
+}
+
+
+SAMPLE_HRV_DATA: dict = {
+    "userProfilePK": 12345,
+    "hrvSummary": {
+        "calendarDate": "2026-04-21",
+        "weeklyAvg": 48.5,
+        "lastNightAvg": 52.0,
+        "lastNight5MinHigh": 71.0,
+        "status": "BALANCED",
+        "feedbackPhrase": "BALANCED_1",
+        "baseline": {
+            "lowUpper": 42.0,
+            "balancedLow": 43.0,
+            "balancedUpper": 58.0,
+            "markerValue": 0.5,
+        },
+    },
+    "hrvReadings": [],
+    "startTimestampGMT": "2026-04-20T22:00:00.0",
+    "endTimestampGMT": "2026-04-21T06:00:00.0",
+}
+
+
+SAMPLE_BODY_BATTERY: list = [
+    {
+        "date": "2026-04-21",
+        "charged": 58,
+        "drained": 32,
+        "startTimestampGMT": "2026-04-21T00:00:00.0",
+        "endTimestampGMT": "2026-04-21T23:59:59.0",
+        "bodyBatteryValuesArray": [
+            [1761100200000, 65],
+            [1761100500000, 66],
+        ],
+    }
+]
+
+
+SAMPLE_TRAINING_READINESS: list = [
+    {
+        "userProfilePK": 12345,
+        "calendarDate": "2026-04-21",
+        "timestamp": "2026-04-21T06:12:00.0",
+        "timestampLocal": "2026-04-21T10:12:00.0",
+        "deviceId": 3412882339,
+        "score": 72,
+        "level": "HIGH",
+        "feedbackLong": "You are well recovered.",
+        "feedbackShort": "READY",
+        "sleepScore": 84,
+        "sleepScoreFactorPercent": 85,
+        "recoveryTime": 0,
+        "recoveryTimeChangePhrase": "REACHED_ZERO",
+        "acwrFactorPercent": 90,
+        "hrvFactorPercent": 80,
+        "inputContext": "AFTER_WAKEUP_RESET",
+    }
+]
+
+
+SAMPLE_ACTIVITY: list = [
+    {
+        "activityId": 19876543210,
+        "activityName": "Morning Run",
+        "startTimeLocal": "2026-04-21 06:30:00",
+        "startTimeGMT": "2026-04-21 02:30:00",
+        "activityType": {
+            "typeId": 1,
+            "typeKey": "running",
+            "parentTypeId": 17,
+            "isHidden": False,
+        },
+        "duration": 2400.0,
+        "movingDuration": 2380.0,
+        "distance": 6200.0,
+        "elevationGain": 45.0,
+        "elevationLoss": 42.0,
+        "averageHR": 148.0,
+        "maxHR": 172.0,
+        "calories": 512.0,
+        "aerobicTrainingEffect": 3.2,
+        "anaerobicTrainingEffect": 0.8,
+        "activityTrainingLoad": 98.5,
+        "averageRunningCadenceInStepsPerMinute": 178.0,
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Accessor plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_typed_returns_typed_garmin(garmin: garminconnect.Garmin) -> None:
+    """``g.typed`` returns a ``TypedGarmin`` wrapping the same instance."""
+    assert isinstance(garmin.typed, TypedGarmin)
+    assert garmin.typed._garmin is garmin
+
+
+def test_typed_is_cached(garmin: garminconnect.Garmin) -> None:
+    """``g.typed`` returns the same wrapper across calls (cached_property)."""
+    assert garmin.typed is garmin.typed
+
+
+# ---------------------------------------------------------------------------
+# Happy path — each wrapper returns the expected model with key fields set
+# ---------------------------------------------------------------------------
+
+
+def test_get_stats_returns_daily_stats(garmin: garminconnect.Garmin) -> None:
+    garmin.get_stats = MagicMock(return_value=SAMPLE_DAILY_STATS)
+
+    stats = garmin.typed.get_stats("2026-04-21")
+
+    assert isinstance(stats, DailyStats)
+    assert stats.total_steps == 8500
+    assert stats.resting_heart_rate == 54
+    assert stats.moderate_intensity_minutes == 22
+    assert stats.body_battery_highest_value == 92
+    garmin.get_stats.assert_called_once_with("2026-04-21")
+
+
+def test_get_user_summary_returns_daily_stats(garmin: garminconnect.Garmin) -> None:
+    """``get_user_summary`` uses the same ``DailyStats`` model."""
+    garmin.get_user_summary = MagicMock(return_value=SAMPLE_DAILY_STATS)
+
+    stats = garmin.typed.get_user_summary("2026-04-21")
+
+    assert isinstance(stats, DailyStats)
+    assert stats.total_steps == 8500
+    garmin.get_user_summary.assert_called_once_with("2026-04-21")
+
+
+def test_get_sleep_data_returns_nested_dto(garmin: garminconnect.Garmin) -> None:
+    garmin.get_sleep_data = MagicMock(return_value=SAMPLE_SLEEP_DATA)
+
+    sleep = garmin.typed.get_sleep_data("2026-04-21")
+
+    assert isinstance(sleep, SleepData)
+    assert sleep.daily_sleep_dto is not None
+    assert sleep.daily_sleep_dto.sleep_time_seconds == 25200
+    assert sleep.daily_sleep_dto.deep_sleep_seconds == 5400
+    assert sleep.daily_sleep_dto.avg_sleep_hrv == 52.3
+    # Nested scores are also typed
+    assert sleep.daily_sleep_dto.sleep_scores is not None
+    assert sleep.daily_sleep_dto.sleep_scores.overall is not None
+    assert sleep.daily_sleep_dto.sleep_scores.overall.value == 84
+
+
+def test_get_hrv_data_returns_hrv_model(garmin: garminconnect.Garmin) -> None:
+    garmin.get_hrv_data = MagicMock(return_value=SAMPLE_HRV_DATA)
+
+    hrv = garmin.typed.get_hrv_data("2026-04-21")
+
+    assert isinstance(hrv, HrvData)
+    assert hrv.hrv_summary is not None
+    assert hrv.hrv_summary.weekly_avg == 48.5
+    assert hrv.hrv_summary.status == "BALANCED"
+    assert hrv.hrv_summary.baseline is not None
+    assert hrv.hrv_summary.baseline.balanced_upper == 58.0
+
+
+def test_get_hrv_data_passes_through_none(garmin: garminconnect.Garmin) -> None:
+    """``get_hrv_data`` may legitimately return ``None`` — the wrapper keeps that."""
+    garmin.get_hrv_data = MagicMock(return_value=None)
+
+    assert garmin.typed.get_hrv_data("2026-04-21") is None
+
+
+def test_get_body_battery_returns_list(garmin: garminconnect.Garmin) -> None:
+    garmin.get_body_battery = MagicMock(return_value=SAMPLE_BODY_BATTERY)
+
+    entries = garmin.typed.get_body_battery("2026-04-21", "2026-04-21")
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert isinstance(entry, BodyBatteryEntry)
+    assert entry.date == "2026-04-21"
+    assert entry.charged == 58
+    assert entry.drained == 32
+    assert entry.body_battery_values_array == [[1761100200000, 65], [1761100500000, 66]]
+
+
+def test_get_body_battery_non_list_returns_empty(garmin: garminconnect.Garmin) -> None:
+    """Defensive: if Garmin returns something unexpected, return ``[]``."""
+    garmin.get_body_battery = MagicMock(return_value=None)
+
+    assert garmin.typed.get_body_battery("2026-04-21") == []
+
+
+def test_get_training_readiness_returns_list(garmin: garminconnect.Garmin) -> None:
+    """Garmin returns a list of snapshots even though the raw method is typed as dict."""
+    garmin.get_training_readiness = MagicMock(return_value=SAMPLE_TRAINING_READINESS)
+
+    readings = garmin.typed.get_training_readiness("2026-04-21")
+
+    assert len(readings) == 1
+    r = readings[0]
+    assert isinstance(r, TrainingReadiness)
+    assert r.score == 72
+    assert r.level == "HIGH"
+    assert r.recovery_time == 0
+    assert r.recovery_time_change_phrase == "REACHED_ZERO"
+    assert r.input_context == "AFTER_WAKEUP_RESET"
+
+
+def test_get_training_readiness_non_list_returns_empty(
+    garmin: garminconnect.Garmin,
+) -> None:
+    garmin.get_training_readiness = MagicMock(return_value={})
+
+    assert garmin.typed.get_training_readiness("2026-04-21") == []
+
+
+def test_get_activities_by_date_returns_list(garmin: garminconnect.Garmin) -> None:
+    garmin.get_activities_by_date = MagicMock(return_value=SAMPLE_ACTIVITY)
+
+    activities = garmin.typed.get_activities_by_date("2026-04-21", "2026-04-21")
+
+    assert len(activities) == 1
+    a = activities[0]
+    assert isinstance(a, Activity)
+    assert a.activity_id == 19876543210
+    assert a.activity_name == "Morning Run"
+    assert a.distance == 6200.0
+    assert a.activity_type is not None
+    assert a.activity_type.type_key == "running"
+
+
+def test_get_activities_by_date_forwards_optional_args(
+    garmin: garminconnect.Garmin,
+) -> None:
+    """Activity filters pass through to the underlying method unchanged."""
+    garmin.get_activities_by_date = MagicMock(return_value=[])
+
+    garmin.typed.get_activities_by_date(
+        "2026-01-01", "2026-04-21", activitytype="running", sortorder="asc"
+    )
+
+    garmin.get_activities_by_date.assert_called_once_with(
+        "2026-01-01", "2026-04-21", "running", "asc"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema tolerance — extra fields, missing fields
+# ---------------------------------------------------------------------------
+
+
+def test_extra_fields_are_tolerated(garmin: garminconnect.Garmin) -> None:
+    """Garmin can (and does) add fields; they must not break validation."""
+    payload = {**SAMPLE_DAILY_STATS, "brandNewFieldFromGarmin2030": "hello"}
+    garmin.get_stats = MagicMock(return_value=payload)
+
+    stats = garmin.typed.get_stats("2026-04-21")
+
+    # Unknown field is preserved in model_extra for callers that want it
+    assert stats.model_extra is not None
+    assert stats.model_extra.get("brandNewFieldFromGarmin2030") == "hello"
+
+
+def test_missing_fields_default_to_none(garmin: garminconnect.Garmin) -> None:
+    """An almost-empty response must still validate."""
+    garmin.get_stats = MagicMock(return_value={"userProfileId": 1})
+
+    stats = garmin.typed.get_stats("2026-04-21")
+
+    assert stats.user_profile_id == 1
+    assert stats.total_steps is None
+    assert stats.resting_heart_rate is None
+
+
+# ---------------------------------------------------------------------------
+# Validation error carries the raw payload
+# ---------------------------------------------------------------------------
+
+
+def test_validation_error_preserves_raw(garmin: garminconnect.Garmin) -> None:
+    """Structural failures raise a typed error with ``.raw`` set."""
+    # A list where a dict is expected — structural mismatch
+    bad_payload = ["not", "a", "dict"]
+    garmin.get_stats = MagicMock(return_value=bad_payload)
+
+    with pytest.raises(GarminConnectResponseValidationError) as excinfo:
+        garmin.typed.get_stats("2026-04-21")
+
+    assert excinfo.value.raw is bad_payload
+    assert excinfo.value.pydantic_error is not None
+    assert "get_stats" in str(excinfo.value)


### PR DESCRIPTION
Closes #354 (once merged).

Implements **Option D** from the issue discussion: a lazy `g.typed` namespace that wraps a small set of high-value read endpoints with Pydantic response models, while leaving the 132 existing methods entirely untouched.

```python
g = Garmin(email, password)
raw = g.get_stats(date)           # dict[str, Any] — unchanged
stats = g.typed.get_stats(date)   # DailyStats (Pydantic model)
print(stats.total_steps, stats.resting_heart_rate)
```

Opening as **draft** so you can veto any of the design choices below before I polish / land.

## Decisions I made (please flag any you'd change)

| Decision | What I did | Why |
|---|---|---|
| **Validation failure behavior** | Raise `GarminConnectResponseValidationError` with the unvalidated response preserved as `.raw` | Loud by default; callers can `try/except` and still access the data. The alternative (silent fallback to dict) was the one open UX question you hadn't weighed in on — happy to flip to silent-fallback if you'd prefer. |
| **Scope of first PR** | 7 methods / 6 models (stats, sleep, hrv, body battery, readiness, activities) vs the 10–15 you suggested | Keeps the initial diff reviewable. Easy to add more in follow-up PRs once the pattern is blessed. |
| **`extra='allow'` + all fields `Optional`** | Yes | Tolerates schema drift (new fields on new firmware) and partial responses (privacy-protected accounts, missing device data) without 500'ing on real users. |
| **`[typed]` extra, not core dep** | Kept pydantic optional — `g.typed` lazy-imports the module and raises a clear install hint if pydantic is missing | Matches your preference expressed in the issue. Zero footprint change for existing users. |
| **Experimental marker** | Module + class docstrings mark it experimental | Want room to reshape the surface if real usage exposes problems before we commit to stability. |
| **`populate_by_name=True`** | Yes | Lets users construct models from snake_case or camelCase in tests / custom flows. Doesn't affect runtime API parsing. |
| **Training readiness typed as `list[TrainingReadiness]`** | Yes, even though `Garmin.get_training_readiness` is annotated `dict[str, Any]` | The live endpoint returns a list of snapshots — the existing annotation is stale. Not fixing that in this PR, just reflecting real shape in the typed layer. |

## Scope

| Method | Typed return |
|---|---|
| `get_stats`, `get_user_summary` | `DailyStats` |
| `get_sleep_data` | `SleepData` (nested `DailySleepDTO`) |
| `get_hrv_data` | `HrvData \| None` |
| `get_body_battery` | `list[BodyBatteryEntry]` |
| `get_training_readiness` | `list[TrainingReadiness]` |
| `get_activities_by_date` | `list[Activity]` |

## Tests

16 new mocked tests in `tests/test_typed.py`. All 107 mock-based tests still pass.

Covered scenarios:
- accessor returns a cached `TypedGarmin`
- each wrapper delegates to the raw method and validates the result
- extra fields land in `model_extra` (no validation failure)
- missing fields default to `None`
- structural validation failures raise `GarminConnectResponseValidationError` with `.raw`
- list endpoints with non-list responses return `[]`
- `get_hrv_data` `None` passes through unchanged

## Out of scope (follow-ups)

- **README** — intentionally not touching it in this PR; happy to follow up with a "Typed responses (experimental)" section once the design is blessed.
- **More models** — stress, respiration, SpO2, training status, max metrics, devices, weigh-ins all candidates for a second pass.
- **Fix the stale `dict[str, Any]` annotation on `get_training_readiness`** — separate PR, doesn't need to block this.
- **Testing the pydantic-missing ImportError path** — marked `pragma: no cover`; happy to add an integration test if you want.

## Verification

- `pdm run ruff check garminconnect/typed.py tests/test_typed.py` — clean
- `pdm run mypy garminconnect/typed.py` — clean
- `black -l 88 --target-version py313` — clean
- `isort --profile black` — clean
- `pytest tests/test_typed.py` — 16 passed
- Full mock-based suite (`test_garmin_unit`, `test_retry_decorator`, `test_workout_constants`, `test_typed`) — 107 passed, 0 regressions

Let me know if the direction is off and I'll rework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional typed response validation layer, accessible via a new .typed accessor (requires installation of the optional "typed" extra). Provides structured, validated results for stats, sleep, HRV, body battery, training readiness, and activity endpoints; validation errors preserve original responses for debugging.

* **Tests**
  * New test suite covering the typed accessor, model validation, defensive handling of unexpected responses, and error preservation.

* **Chore**
  * Optional extra renamed to "typed" for the typed validation feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->