### PR TITLE
fix: route DI token endpoint to garmin.cn for CN accounts

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -158,6 +158,10 @@ class Client:
         self._connectapi = f"https://connectapi.{domain}"
         # Portal service URL is domain-aware for CN support
         self._portal_service_url = f"https://connect.{domain}/app"
+        # DI auth host is domain-aware too — CN users live on diauth.garmin.cn
+        # and don't exist in the .com user database. Without this, token refresh
+        # for CN accounts fails with 400 invalid_grant.
+        self._di_token_url = f"https://diauth.{domain}/di-oauth2-service/oauth/token"
 
         # Native Bearer tokens (primary auth)
         self.di_token: str | None = None
@@ -901,7 +905,7 @@ class Client:
 
         for client_id in DI_CLIENT_IDS:
             r = self._http_post(
-                DI_TOKEN_URL,
+                self._di_token_url,
                 headers=_native_headers(
                     {
                         "Authorization": _build_basic_auth(client_id),
@@ -954,7 +958,7 @@ class Client:
         if not self.di_refresh_token or not self.di_client_id:
             raise GarminConnectAuthenticationError("No DI refresh token available")
         r = self._http_post(
-            DI_TOKEN_URL,
+            self._di_token_url,
             headers=_native_headers(
                 {
                     "Authorization": _build_basic_auth(self.di_client_id),


### PR DESCRIPTION
## Bug

`is_cn=True` correctly routes the SSO and Connect API endpoints via the domain-aware `_sso` / `_connect` / `_connectapi` attributes, but the DI OAuth2 token endpoint (`DI_TOKEN_URL`) stays hardcoded to `diauth.garmin.com`. CN users don't exist in the `.com` user database, so:

- **Initial token exchange (post-SSO)** succeeds for fresh logins — the `.com` DI endpoint accepts the ticket and issues a token whose JWT payload still carries `iss=https://diauth.garmin.cn` (the issuer claim correctly reflects the CN auth server, but the token was minted by `.com`).
- **Token refresh fails** with HTTP 400:
  ```
  {"error":"invalid_grant","error_description":"User doesn't exist in DB for GarminGUID: <uuid>"}
  ```
  because the refresh path looks up the user by GUID in the host's DB, and CN users only exist on `diauth.garmin.cn`.

This matters in practice: the access token's TTL is ~4 hours, so any CN account that stays logged in longer than a single session will hit the refresh path and break. Cron-driven sync jobs are the canonical case.

## Reproduce

```python
from garminconnect import Garmin
g = Garmin("user@example.com", "password", is_cn=True)
g.login()
# Wait > 4 hours (or manually call g.client._refresh_di_token())
g.get_user_summary("2026-04-26")
# → GarminConnectAuthenticationError: DI token refresh failed: 400
#    {"error":"invalid_grant","error_description":"User doesn't exist in DB for GarminGUID: ..."}
```

## Fix

Store `_di_token_url` as an instance attribute built from `domain` (same pattern as `_sso` / `_connect` / `_connectapi`), and use it in `_exchange_ticket()` and `_refresh_di_token()`. The module-level `DI_TOKEN_URL` constant is kept for backwards compatibility with external imports.

After fix: refresh hits `https://diauth.garmin.cn/di-oauth2-service/oauth/token` → 200.

## Verification

Manually patched the same code locally (monkey-patching `garminconnect.client.DI_TOKEN_URL` to the CN variant before calling `_refresh_di_token()`) — refresh succeeds, subsequent `connectapi()` calls work, persisted tokens reload cleanly across processes. Verified against a real `garmin.cn` account.

## Notes

- `DI_GRANT_TYPE` is left as the `.com` URI because it's a brand-namespace OAuth2 grant_type identifier (RFC 6749), not an HTTP endpoint.
- This fix is minimal and local — no behavior changes for `garmin.com` users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled OAuth token refresh for non-.com domains through region-specific authentication support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->