### PR TITLE
fix: skip mobile login strategies for non-garmin.com domains (CN support)

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -252,16 +252,22 @@ class Client:
             (None, None) on success; ("needs_mfa", None) when return_on_mfa=True.
 
         """
-        strategies: list[tuple[str, Any]] = [
-            ("mobile+cffi", lambda: self._mobile_login_cffi(email, password)),
-            ("mobile+requests", lambda: self._mobile_login_requests(email, password)),
+        # Mobile login strategies require mobile.integration.garmin.com which
+        # only exists for garmin.com domain. Skip them for other domains (e.g. garmin.cn).
+        strategies: list[tuple[str, Any]] = []
+        if self.domain == "garmin.com":
+            strategies.extend([
+                ("mobile+cffi", lambda: self._mobile_login_cffi(email, password)),
+                ("mobile+requests", lambda: self._mobile_login_requests(email, password)),
+            ])
+        strategies.extend([
             ("widget+cffi", lambda: self._widget_web_login(email, password)),
             ("portal+cffi", lambda: self._portal_web_login_cffi(email, password)),
             (
                 "portal+requests",
                 lambda: self._portal_web_login_requests(email, password),
             ),
-        ]
+        ])
 
         last_err: Exception | None = None
         rate_limited_count = 0


### PR DESCRIPTION
## Problem

Mobile login strategies use `mobile.integration.garmin.com` which **does not exist** for other domains like `garmin.cn`. This causes DNS resolution failures and breaks login for Chinese users.

## Changes

- Skip `mobile+cffi` and `mobile+requests` strategies when `domain != "garmin.com"`
- Fall back to `widget` and `portal` strategies for CN domain

## Testing

Tested successfully with `garmin.cn` login:
```python
from garminconnect import Garmin
client = Garmin(email, password, is_cn=True)
client.login()
# ✅ Login successful!
# ✅ API calls work (get_user_profile, get_activities, get_devices)
```

## Error before fix

```
WARNING:garminconnect.client:mobile+cffi failed: Failed to perform, curl: (6) Could not resolve host: mobile.integration.garmin.com
WARNING:garminconnect.client:mobile+requests failed: HTTPSConnectionPool(host='mobile.integration.garmin.com', port=443): Max retries exceeded
garminconnect.exceptions.GarminConnectAuthenticationError: JWT_WEB cookie not set after ticket consumption
```

Fixes issue where `is_cn=True` login fails due to non-existent mobile endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login authentication handling for different domain types. Authentication now uses optimized connection strategies appropriate for each service endpoint, ensuring more reliable access across all supported domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cyberjunky/python-garminconnect/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->