### PR TITLE
Add set_activity_description() method

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2038,6 +2038,13 @@ class Garmin:
         logger.debug("Changing activity type: %s", payload)
         return self.client.put("connectapi", url, json=payload, api=True)
 
+    def set_activity_description(self, activity_id: str, description: str) -> Any:
+        """Set description for activity with id."""
+        url = f"{self.garmin_connect_activity}/{activity_id}"
+        payload = {"activityId": activity_id, "description": description}
+
+        return self.client.put("connectapi", url, json=payload, api=True)
+
     def create_manual_activity_from_json(self, payload: dict[str, Any]) -> Any:
         url = f"{self.garmin_connect_activity}"
         logger.debug("Uploading manual activity: %s", str(payload))


### PR DESCRIPTION
## Summary

Adds a new method `set_activity_description(activity_id, description)` that lets clients write the activity's description field — the multi-line text shown under "Description" in the Garmin Connect web UI. Today the library reads this field (it appears on the activity detail JSON as top-level `description`) but offers no way to set it.

Implementation mirrors `set_activity_name()`: PUT to `/activity-service/activity/{id}` with `{"activityId": id, "description": text}`. Verified against live Garmin Connect — the server accepts the payload, returns `{}`, and the description is visible both via `get_activity()` and in the web UI after refresh.

```python
from garminconnect import Garmin
api = Garmin(...)
api.login()
api.set_activity_description("12345678", "Tempo run — 5×1k @ 4:00, rest 90s")
```

## Why

The Garmin Connect web UI exposes the Description field on every activity, but the wrapper currently has no setter. Use cases include logging session details that aren't captured by the device (intervals, RPE, equipment used, kettlebell weights, notes), which becomes important when downstream tooling reads activities programmatically and needs richer metadata than the device alone provides.

## Test plan

- [x] Verified locally against my own Garmin account: PUT succeeds, returns `{}`, and the description persists on subsequent `get_activity()` calls and in the web UI.
- [x] `ruff check garminconnect/` — clean.
- [x] `ruff format --check garminconnect/` — clean.
- [x] mypy: no new errors introduced (the two pre-existing `unused-ignore` warnings in `client.py` are unaffected).
- [ ] No unit test added — `set_activity_name()` and `set_activity_type()` also ship without dedicated tests, so this stays consistent with the existing convention. Happy to add a unit test (mocked client.put) if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to update activity descriptions programmatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cyberjunky/python-garminconnect/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->