### PR TITLE
Add set_activity_exercise_sets() method

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2555,6 +2555,24 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def set_activity_exercise_sets(
+        self, activity_id: int | str, payload: dict[str, Any]
+    ) -> Any:
+        """Replace exercise sets for activity with id.
+
+        `payload` is the full body sent to the server, in the same shape as the
+        response from `get_activity_exercise_sets`. Replace-all semantics — the
+        existing `exerciseSets` array is overwritten. Garmin validates the
+        `exercises[].category` (parent) and `exercises[].name` (sub-category)
+        against its FIT enum and returns 400 "Invalid Sub-Category Passed" for
+        unknown values; `name=None` is always accepted under a known parent.
+        """
+        activity_id = str(_validate_positive_integer(int(activity_id), "activity_id"))
+        url = f"{self.garmin_connect_activity}/{activity_id}/exerciseSets"
+        logger.debug("Replacing exercise sets for activity id %s", activity_id)
+
+        return self.client.put("connectapi", url, json=payload, api=True)
+
     def get_activity_gear(self, activity_id: int | str) -> dict[str, Any]:
         """Return gears used for activity id."""
         activity_id = str(_validate_positive_integer(int(activity_id), "activity_id"))


### PR DESCRIPTION
## Summary

Adds the writer that pairs with the existing `get_activity_exercise_sets()`. Replaces an activity's `exerciseSets` via `PUT /activity-service/activity/{id}/exerciseSets`.

```python
from garminconnect import Garmin
api = Garmin(...)
api.login()

payload = {
    \"activityId\": 23027505383,
    \"exerciseSets\": [
        {
            \"exercises\": [{\"category\": \"SQUAT\", \"name\": \"GOBLET_SQUAT\", \"probability\": 100.0}],
            \"duration\": 20.0,
            \"repetitionCount\": 8,
            \"weight\": 24.0,
            \"setType\": \"ACTIVE\",
            \"startTime\": \"2026-05-27T05:20:24.0\",
            \"wktStepIndex\": None,
            \"messageIndex\": 0,
        },
        # ... more sets
    ],
}
api.set_activity_exercise_sets(\"23027505383\", payload)
```

## Why

The Garmin Connect web UI lets users manually edit the exercise breakdown of strength activities — the watch's accelerometer-based auto-detection is unreliable for varied workouts (kettlebell, complex circuits, etc.). The wrapper has had the reader for a long time; adding the writer enables downstream tools to fix or enrich the breakdown programmatically.

## Behavior notes (documented in the docstring)

- **Replace-all semantics**: the new `exerciseSets` array overwrites the existing one. Callers should back up the prior payload before writing.
- **Strict validation by the server**: `exercises[].category` (parent FIT category) and `exercises[].name` (sub-category) are validated against Garmin's internal enum. Unknown values return `400 Invalid Sub-Category Passed in the request`. `name=None` is always accepted under a known parent — useful for exercises with no exact sub-category match (e.g. two-hand kettlebell swing has no valid HIP_SWING sub-category).

## Test plan

- [x] Verified against my own Garmin account: replaced a real strength activity's auto-detected single UNKNOWN block with 42 properly structured sets (2 warm-up REST + 40 EMOM ACTIVE), various categories (HIP_SWING, PUSH_UP/INCLINE_PUSH_UP, SQUAT/GOBLET_SQUAT, ROW/RENEGADE_ROW). All persisted; Garmin's web UI strength view now shows the correct exercise breakdown.
- [x] `ruff check garminconnect/` — clean
- [x] `ruff format --check garminconnect/` — clean
- [ ] No unit test added — matches the convention of the other setters (`set_activity_name`, `set_activity_type`, and `set_activity_description` from [PR #367](https://github.com/cyberjunky/python-garminconnect/pull/367)). Happy to add a mocked unit test if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating exercise sets for your activities. This new functionality allows you to efficiently modify and manage the exercises associated with your workout records, giving you greater control over your activity details and enabling customization of exercise information for each workout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cyberjunky/python-garminconnect/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->