### PR TITLE
fix: detect email-based MFA in widget SSO login

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -619,7 +619,13 @@ class Client:
                 f"Widget login: account restricted '{title}'"
             )
 
-        if "MFA" in title:
+        # MFA challenge. The page title depends on the MFA method: authenticator
+        # (TOTP) apps return "Enter MFA code for login", while email one-time
+        # codes return "GARMIN Authentication Application". Both are completed
+        # through the same verifyMFA endpoint, so detect either. Email MFA is
+        # mandatory on ECG-capable devices (e.g. Venu 4, Fenix 8), and the
+        # previous literal "MFA"-only check locked those accounts out entirely.
+        if "mfa" in title_lower or "authentication application" in title_lower:
             self._mfa_session = sess
             self._mfa_login_params = signin_params
             self._mfa_post_headers = {"Referer": r.url}

--- a/tests/test_widget_mfa.py
+++ b/tests/test_widget_mfa.py
@@ -1,0 +1,91 @@
+"""Tests for SSO widget-login MFA detection.
+
+In-process, no network: a fake ``curl_cffi`` session feeds the widget login
+strategy canned HTML so we can assert how each post-login page title is
+handled. Covers both MFA variants and guards against over-broad detection.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from garminconnect import client as client_mod
+from garminconnect.client import _MFARequired
+from garminconnect.exceptions import GarminConnectConnectionError
+
+# The signin GET must yield a CSRF token for the flow to reach the POST.
+_CSRF_HTML = '<input name="_csrf" value="tok123"/>'
+
+
+def _resp(text="", status_code=200, url="https://sso.garmin.com/sso/signin"):
+    return SimpleNamespace(
+        text=text,
+        status_code=status_code,
+        url=url,
+        ok=200 <= status_code < 400,
+    )
+
+
+def _page(title):
+    return f"<html><head><title>{title}</title></head><body></body></html>"
+
+
+class _FakeSession:
+    """Minimal stand-in for curl_cffi's Session for the widget flow.
+
+    Every GET returns a CSRF-bearing page (covers both the embed and signin
+    GETs); the credential POST returns the caller-supplied page carrying the
+    title under test.
+    """
+
+    def __init__(self, post_text):
+        self._post_text = post_text
+
+    def get(self, url, **kwargs):
+        return _resp(text=_CSRF_HTML)
+
+    def post(self, url, **kwargs):
+        return _resp(text=self._post_text)
+
+
+@contextlib.contextmanager
+def _widget_session(post_text):
+    """Patch the widget flow to drive ``_FakeSession`` with no real network/delay."""
+    with (
+        patch.object(client_mod, "HAS_CFFI", True),
+        patch.object(
+            client_mod,
+            "cffi_requests",
+            SimpleNamespace(Session=lambda *a, **k: _FakeSession(post_text)),
+        ),
+        patch.object(client_mod.time, "sleep"),
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "GARMIN Authentication Application",  # email one-time-code MFA
+        "Enter MFA code for login",  # authenticator-app (TOTP) MFA
+    ],
+)
+def test_mfa_titles_trigger_mfa(title):
+    """Both MFA page-title variants must enter the MFA completion flow."""
+    c = client_mod.Client()
+    with _widget_session(_page(title)), pytest.raises(_MFARequired):
+        c._widget_web_login("e@x.com", "pw")
+
+    assert c._mfa_flow == "widget"
+    assert c._widget_last_resp is not None
+
+
+def test_unexpected_title_still_errors():
+    """A genuinely unknown page must NOT be misread as an MFA challenge."""
+    c = client_mod.Client()
+    with _widget_session(_page("Some Unrelated Page")), pytest.raises(
+        GarminConnectConnectionError, match="unexpected title"
+    ):
+        c._widget_web_login("e@x.com", "pw")


### PR DESCRIPTION
## Problem

The `widget+cffi` login strategy only treats the post-login page as an MFA challenge when its HTML `<title>` contains the literal substring `"MFA"`:

```python
if "MFA" in title:
    ...
    raise _MFARequired()

if title != "Success":
    raise GarminConnectConnectionError(f"Widget login: unexpected title '{title}'")
```

That works for authenticator-app (TOTP) MFA, whose page is titled **`Enter MFA code for login`**. But **email-based one-time-code MFA** returns a page titled **`GARMIN Authentication Application`**, which contains no `"MFA"`. Login therefore falls through to the generic `Widget login: unexpected title '...'` error and the user is **never prompted for the emailed code**.

Garmin permanently enforces MFA on ECG-capable devices (e.g. **Venu 4, Fenix 8**), where email is a common method — so affected accounts can't authenticate via the widget flow at all. This is the same symptom previously reported for the old garth flow in #242.

## Fix

Broaden the MFA detection in `_widget_web_login` to recognize the email-MFA title as well, reusing the already-computed `title_lower`:

```python
if "mfa" in title_lower or "authentication application" in title_lower:
```

No change is needed to MFA completion: both variants are already verified through the same `/sso/verifyMFA/loginEnterMfaCode` endpoint in `_complete_mfa_widget`.

## Verification

- ✅ Verified **end-to-end against a live email-MFA account** — `login()` now prompts for the emailed code and authenticates successfully.
- ✅ Adds in-process unit tests (no network) for both MFA title variants and a negative case ensuring unrelated titles still raise the `unexpected title` error.
- ✅ Full in-process suite passes (`test_widget_mfa`, `test_login_recovery`, `test_garmin_unit`, `test_retry_decorator` → 101 passed); `ruff check garminconnect/client.py` clean.

## Scope

One-line detection change plus tests. No behavioral change for TOTP MFA, successful logins, or the credential/error paths (the negative test guards against over-broad matching).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced multi-factor authentication detection during Garmin Connect login to recognize additional authentication page variants, improving reliability and reducing unexpected errors during the sign-in process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->