### PR TITLE
feat: add update_workout to edit a workout in place

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2792,6 +2792,35 @@ class Garmin:
             raise ValueError("workout_json must be a JSON object or array")
         return self.client.post("connectapi", url, json=payload, api=True)
 
+    def update_workout(
+        self, workout_id: int | str, workout_json: dict[str, Any] | str
+    ) -> dict[str, Any]:
+        """Update (replace) an existing workout in place using json data.
+
+        Garmin's workout endpoint replaces the whole workout via PUT, so
+        ``workout_json`` must be the complete structure (as returned by
+        ``get_workout_by_id`` or built the same way as for ``upload_workout``).
+        The workout keeps its id, so any calendar schedules pointing at it stay
+        valid. ``workoutId`` in the body is forced to match ``workout_id``.
+        """
+        workout_id = _validate_positive_integer(int(workout_id), "workout_id")
+        url = f"{self.garmin_workouts}/workout/{workout_id}"
+        logger.debug("Updating workout using %s", url)
+
+        if isinstance(workout_json, str):
+            import json as _json
+
+            try:
+                payload = _json.loads(workout_json)
+            except Exception as e:
+                raise ValueError(f"invalid workout_json string: {e}") from e
+        else:
+            payload = workout_json
+        if not isinstance(payload, dict):
+            raise ValueError("workout_json must be a JSON object")
+        body = payload | {"workoutId": workout_id}
+        return self.client.put("connectapi", url, json=body, api=True)
+
     def upload_running_workout(self, workout: Any) -> dict[str, Any]:
         """Upload a typed running workout.
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -509,3 +509,65 @@ class TestResponseHandling:
         assert last_params["start"] == "40"
         assert last_params["startDate"] == "2026-03-01"
         assert last_params["endDate"] == "2026-03-31"
+
+
+# ---------------------------------------------------------------------------
+# update_workout (in-place PUT)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkout:
+    """``update_workout`` PUTs the full workout to /workout-service/workout/<id>."""
+
+    def test_puts_to_workout_url_with_injected_id(
+        self, garmin: garminconnect.Garmin
+    ):
+        workout = {"workoutName": "Edited", "sportType": {"sportTypeId": 1}}
+        with patch.object(garmin, "client") as client:
+            client.put.return_value = {"workoutId": 123, "workoutName": "Edited"}
+            result = garmin.update_workout(123, workout)
+
+        args, kwargs = client.put.call_args
+        assert args[0] == "connectapi"
+        assert args[1] == "/workout-service/workout/123"
+        assert kwargs["api"] is True
+        assert kwargs["json"]["workoutId"] == 123
+        assert kwargs["json"]["workoutName"] == "Edited"
+        assert result == {"workoutId": 123, "workoutName": "Edited"}
+
+    def test_injected_id_overrides_stray_workout_id(
+        self, garmin: garminconnect.Garmin
+    ):
+        workout = {"workoutId": 999, "workoutName": "Edited"}
+        with patch.object(garmin, "client") as client:
+            garmin.update_workout(123, workout)
+
+        assert client.put.call_args.kwargs["json"]["workoutId"] == 123
+        # caller dict is not mutated
+        assert workout["workoutId"] == 999
+
+    def test_accepts_json_string(self, garmin: garminconnect.Garmin):
+        import json as _json
+
+        with patch.object(garmin, "client") as client:
+            garmin.update_workout(123, _json.dumps({"workoutName": "Edited"}))
+
+        assert client.put.call_args.kwargs["json"]["workoutId"] == 123
+
+    def test_rejects_non_positive_id(self, garmin: garminconnect.Garmin):
+        with patch.object(garmin, "client") as client:
+            with pytest.raises(ValueError, match="positive integer"):
+                garmin.update_workout(0, {"workoutName": "Edited"})
+        client.put.assert_not_called()
+
+    def test_rejects_non_dict_payload(self, garmin: garminconnect.Garmin):
+        with patch.object(garmin, "client") as client:
+            with pytest.raises(ValueError, match="must be a JSON object"):
+                garmin.update_workout(123, [1, 2, 3])
+        client.put.assert_not_called()
+
+    def test_rejects_invalid_json_string(self, garmin: garminconnect.Garmin):
+        with patch.object(garmin, "client") as client:
+            with pytest.raises(ValueError, match="invalid workout_json string"):
+                garmin.update_workout(123, "{not json")
+        client.put.assert_not_called()


### PR DESCRIPTION
`PUT /workout-service/workout/{id}` replaces the whole workout while keeping its id, so calendar schedules pointing at it stay valid. Mirrors `upload_workout`; forces `workoutId` in the body to match the path id and validates a positive integer id.

Without this, to update a workout, it needs to be recreated (+ potentially be rescheduled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API method to update existing workout templates.
  - Accepts workout details as either structured data or a JSON string.
  - Automatically sets `workoutId` in the update to the provided ID.

- **Bug Fixes**
  - Added input validation to prevent updates with non-positive IDs, non-object payloads, or invalid JSON strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->