### PR TITLE
feat: raise GarminConnectNotFoundError for HTTP 404

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -3173,9 +3173,10 @@ class Garmin:
         return self.connectapi(url, params=params)
 
 
-from .exceptions import (  # noqa: E402
+from .exceptions import (  # noqa: E402, F401
     GarminConnectAuthenticationError,
     GarminConnectConnectionError,
     GarminConnectInvalidFileFormatError,
+    GarminConnectNotFoundError,
     GarminConnectTooManyRequestsError,
 )

--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -39,6 +39,7 @@ except ImportError:
 from .exceptions import (
     GarminConnectAuthenticationError,
     GarminConnectConnectionError,
+    GarminConnectNotFoundError,
     GarminConnectTooManyRequestsError,
 )
 
@@ -1346,6 +1347,9 @@ class Client:
             except Exception:
                 if len(resp.text) < 500:
                     error_msg += f" - {resp.text}"
+            # A 404 is a missing resource, not a connectivity failure.
+            if resp.status_code == 404:
+                raise GarminConnectNotFoundError(error_msg)
             raise GarminConnectConnectionError(error_msg)
 
         return resp

--- a/garminconnect/exceptions.py
+++ b/garminconnect/exceptions.py
@@ -2,6 +2,16 @@ class GarminConnectConnectionError(Exception):
     """Raised when communication ended in error."""
 
 
+class GarminConnectNotFoundError(GarminConnectConnectionError):
+    """Raised when a requested resource does not exist (HTTP 404).
+
+    Subclasses GarminConnectConnectionError for backwards compatibility, so
+    existing ``except GarminConnectConnectionError`` handlers keep working while
+    callers can now catch a missing resource specifically (e.g. deleting an
+    already-deleted workout).
+    """
+
+
 class GarminConnectTooManyRequestsError(Exception):
     """Raised when rate limit is exceeded."""
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -509,3 +509,51 @@ class TestResponseHandling:
         assert last_params["start"] == "40"
         assert last_params["startDate"] == "2026-03-01"
         assert last_params["endDate"] == "2026-03-31"
+
+
+# ---------------------------------------------------------------------------
+# _run_request: HTTP status -> exception mapping
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class TestHttpErrorMapping:
+    """A 404 raises GarminConnectNotFoundError; other >=400 stay ConnectionError."""
+
+    def _client(self, monkeypatch, resp):
+        g = garminconnect.Garmin()
+        c = g.client
+        monkeypatch.setattr(c, "get_api_headers", dict)
+        monkeypatch.setattr(c._api_session, "request", lambda *a, **k: resp)
+        return c
+
+    def test_404_raises_not_found(self, monkeypatch):
+        c = self._client(monkeypatch, _FakeResp(404, {"error": "NotFoundException"}))
+        with pytest.raises(garminconnect.GarminConnectNotFoundError):
+            c._run_request("DELETE", "workout-service/workout/1")
+
+    def test_not_found_is_backwards_compatible(self, monkeypatch):
+        # Existing handlers catching GarminConnectConnectionError must still work.
+        c = self._client(monkeypatch, _FakeResp(404, {"error": "NotFoundException"}))
+        with pytest.raises(garminconnect.GarminConnectConnectionError):
+            c._run_request("GET", "workout-service/workout/1")
+
+    def test_500_stays_connection_error_not_not_found(self, monkeypatch):
+        c = self._client(monkeypatch, _FakeResp(500, {"message": "boom"}))
+        with pytest.raises(garminconnect.GarminConnectConnectionError):
+            c._run_request("GET", "x")
+        try:
+            c._run_request("GET", "x")
+        except garminconnect.GarminConnectNotFoundError as err:
+            raise AssertionError("500 must not be GarminConnectNotFoundError") from err
+        except garminconnect.GarminConnectConnectionError:
+            pass

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -549,11 +549,6 @@ class TestHttpErrorMapping:
 
     def test_500_stays_connection_error_not_not_found(self, monkeypatch):
         c = self._client(monkeypatch, _FakeResp(500, {"message": "boom"}))
-        with pytest.raises(garminconnect.GarminConnectConnectionError):
+        with pytest.raises(garminconnect.GarminConnectConnectionError) as exc_info:
             c._run_request("GET", "x")
-        try:
-            c._run_request("GET", "x")
-        except garminconnect.GarminConnectNotFoundError as err:
-            raise AssertionError("500 must not be GarminConnectNotFoundError") from err
-        except garminconnect.GarminConnectConnectionError:
-            pass
+        assert not isinstance(exc_info.value, garminconnect.GarminConnectNotFoundError)


### PR DESCRIPTION
Every request with `status >= 400` was treated as `GarminConnectConnectionError`, and therefore a missing resource (e.g. deleting an already-deleted workout, or fetching an id that no longer exists) was reported as a connectivity failure, making it impossible to distinguish between something being 404 not found, and there being actual network issues.

- adds `GarminConnectNotFoundError` and raisees it for HTTP 404
- It subclasses `GarminConnectConnectionError`, so existing `except GarminConnectConnectionError' handlers keep working (no breaking change) while callers can now catch a missing resource specifically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GarminConnectNotFoundError` for missing resources to enable more precise error handling.
  * Exposed the new error at the package level for easier access.

* **Bug Fixes**
  * HTTP 404 responses now raise `GarminConnectNotFoundError` instead of the general connection error.
  * Existing handlers that catch the general connection error remain compatible.
  * HTTP 5xx responses continue to raise the general connection error.

* **Tests**
  * Added unit tests validating the HTTP status-to-exception mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->