### PR TITLE
fix: stop sending percent-encoded commas in get_golf_shot_data

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -14,6 +14,7 @@ from datetime import UTC, date, datetime, timedelta
 from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode
 
 if TYPE_CHECKING:
     from .typed import TypedGarmin
@@ -3150,13 +3151,14 @@ class Garmin:
     def get_golf_shot_data(
         self,
         scorecard_id: int | str,
-        hole_numbers: str = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18",
+        hole_numbers: str | None = None,
     ) -> dict[str, Any]:
         """Return golf shot data for a scorecard and specific holes.
 
         Args:
             scorecard_id: The scorecard ID to get shot data for.
-            hole_numbers: Comma-separated hole numbers (default: all 18).
+            hole_numbers: Comma-separated hole numbers, for example ``"1,2,3"``.
+                When omitted, Garmin returns every hole on the scorecard.
 
         Returns:
             Dictionary containing shot data per hole.
@@ -3164,11 +3166,19 @@ class Garmin:
         """
         scorecard_id = _validate_positive_integer(int(scorecard_id), "scorecard_id")
         url = f"{self.garmin_golf_shot}/{scorecard_id}/hole"
-        params = {"hole-numbers": hole_numbers}
+        # Garmin rejects percent-encoded commas in "hole-numbers", so the query
+        # string is built with commas kept safe. Passing a dict here would let
+        # requests encode them as %2C, which the endpoint answers with
+        # 400 "Invalid hole-numbers in request".
+        params = (
+            None
+            if hole_numbers is None
+            else urlencode({"hole-numbers": hole_numbers}, safe=",")
+        )
         logger.debug(
             "Requesting golf shot data for scorecard %d, holes %s",
             scorecard_id,
-            hole_numbers,
+            "all" if hole_numbers is None else hole_numbers,
         )
         return self.connectapi(url, params=params)
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -266,6 +266,37 @@ class TestUrlConstruction:
         url = mock.call_args[0][0]
         assert url.endswith("/usersummary-service/stats/steps/weekly/2026-03-15/12")
 
+    def test_get_golf_shot_data_omits_hole_numbers_by_default(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value={"holes": []}) as mock:
+            garmin.get_golf_shot_data(12345)
+
+        url = mock.call_args[0][0]
+        assert url.endswith("/gcs-golfcommunity/api/v2/shot/scorecard/12345/hole")
+        # Garmin returns every hole when the parameter is absent. Sending a
+        # comma-separated default instead fails with 400 "Invalid hole-numbers".
+        assert mock.call_args.kwargs["params"] is None
+
+    def test_get_golf_shot_data_keeps_commas_unencoded(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value={"holes": []}) as mock:
+            garmin.get_golf_shot_data(12345, hole_numbers="1,2,3")
+
+        # A dict would be encoded by requests as %2C, which the endpoint rejects.
+        assert mock.call_args.kwargs["params"] == "hole-numbers=1,2,3"
+
+    def test_get_golf_shot_data_escapes_query_separators(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value={"holes": []}) as mock:
+            garmin.get_golf_shot_data(12345, hole_numbers="1,2&injected=evil")
+
+        # Commas stay literal, but & and = must not leak extra query parameters.
+        params = mock.call_args.kwargs["params"]
+        assert params == "hole-numbers=1,2%26injected%3Devil"
+
 
 # ---------------------------------------------------------------------------
 # Parameter limit tests


### PR DESCRIPTION
Fixes the 400 reported in #377.

`get_golf_shot_data()` defaulted `hole_numbers` to `"1,2,3,...,18"` and passed it to `requests` as a dict value. `requests` percent-encodes the commas, and the Garmin endpoint rejects the encoded form, so **every** call failed:

```
GarminConnectConnectionError: API call client error (400):
API Error 400 - {'errorMessage': 'Invalid hole-numbers in request'}
```

I reproduced the encoding independently of the network, so the cause is not in doubt:

```python
>>> from requests.models import PreparedRequest
>>> p = PreparedRequest(); p.prepare_url("https://x.test/hole", {"hole-numbers": "1,2,3"}); p.url
'https://x.test/hole?hole-numbers=1%2C2%2C3'
```

### The change

**Default to `None` and omit the parameter.** @antoine-defrahan's table in the issue shows the endpoint returns all 18 holes when `hole-numbers` is absent — which is exactly what the old default was trying to express. So the common path now sends no parameter at all.

**When holes are given explicitly, build the query string with `urlencode(..., safe=",")`.** Passing `params` as a string keeps commas literal, which is what the endpoint wants:

```python
>>> urlencode({"hole-numbers": "1,2,3"}, safe=",")
'hole-numbers=1,2,3'
```

I went with `urlencode` rather than an f-string because a raw f-string would preserve commas but also let a value containing `&` inject extra query parameters. `urlencode` keeps commas literal while still escaping separators:

```python
>>> urlencode({"hole-numbers": "1,2&injected=evil"}, safe=",")
'hole-numbers=1,2%26injected%3Devil'
```

### Compatibility

The signature default changes from a string to `None`, but observable behavior only improves:

- Callers relying on the default previously got a 400 every time; they now get all 18 holes.
- Callers passing explicit comma-separated holes previously got a 400; they now get the holes they asked for.
- Callers passing a single hole (`"1"`) worked before and still work.

I don't believe any working call changes behavior, but flagging it explicitly since it is a public signature.

### Tests

Three unit tests added to `tests/test_garmin_unit.py`, matching the existing mock-based `TestUrlConstruction` style: the omitted default, commas preserved, and query separators escaped. **All three fail on `master` and pass with this change** — I verified by reverting only the source file and re-running.

```
tests/test_garmin_unit.py::TestUrlConstruction::test_get_golf_shot_data_omits_hole_numbers_by_default PASSED
tests/test_garmin_unit.py::TestUrlConstruction::test_get_golf_shot_data_keeps_commas_unencoded PASSED
tests/test_garmin_unit.py::TestUrlConstruction::test_get_golf_shot_data_escapes_query_separators PASSED

63 passed
```

Full `tests/test_garmin_unit.py` suite is green, and `ruff format --check` reports both files already formatted. The two `SIM117` lint findings in that file are pre-existing at lines 479 and 489, outside this diff.

Used `Refs` rather than `Closes` — happy to switch it if you'd like the issue closed on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Golf shot data requests now retrieve all holes by default.
  * Specific holes can still be requested using comma-separated hole numbers.

* **Bug Fixes**
  * Improved query handling prevents special characters from being interpreted as unintended parameters.
  * Commas in hole selections are preserved for reliable server processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->