### PR TITLE
feat: Add golf club and golf user stats

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -3187,6 +3187,7 @@ class Garmin:
             Dictionary containing club list and distance data.
 
         """
+        limit = _validate_positive_integer(limit, "limit")
         url = f"{self.garmin_golf_club_stats}"
         params = {"per-page": str(limit), "include-stats": "true"}
         logger.debug("Requesting golf club data for the user.")

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -3178,7 +3178,7 @@ class Garmin:
         self,
         limit: int = 1000,
     ) -> dict[str, Any]:
-        """Return golf scorecard summary.
+        """Return golf club names and statistics.
 
         Args:
             limit: Maximum number of results to return.
@@ -3193,10 +3193,10 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_golf_user_stats(self) -> dict[str, Any]:
-        """Return golf scorecard summary.
+        """Return overview of the users golf statistics.
 
         Returns:
-            Dictionary containing club list and distance data.
+            Dictionary containing user stats such as handicap and strokes gained.
 
         """
         url = f"{self.garmin_golf_user_stats}"

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1716,7 +1716,6 @@ class Garmin:
         """Return lifestyle jounal logging data for current user."""
         cdate = _validate_date_format(cdate, "cdate")
         url = f"{self.garmin_connect_daily_lifestyle_jounal_logging_url}?date={cdate}"
-        print(url)
         logger.debug("Requesting lifestyle journal logging data")
 
         return self.connectapi(url)
@@ -3186,12 +3185,13 @@ class Garmin:
             hole_numbers,
         )
         return self.connectapi(url, params=params)
-        
-    def get_golf_club_stats( 
+
+    def get_golf_club_stats(
         self,
         limit: int = 1000,
     ) -> dict[str, Any]:
         """Return golf scorecard summary.
+
         Args:
             limit: Maximum number of results to return.
 
@@ -3201,12 +3201,10 @@ class Garmin:
         """
         url = f"{self.garmin_golf_club_stats}"
         params = {"per-page": str(limit), "include-stats": "true"}
-        logger.debug(
-            "Requesting golf club data for the user."
-        )
+        logger.debug("Requesting golf club data for the user.")
         return self.connectapi(url, params=params)
-    
-    def get_golf_user_stats( self ) -> dict[str, Any]:
+
+    def get_golf_user_stats(self) -> dict[str, Any]:
         """Return golf scorecard summary.
 
         Returns:
@@ -3214,11 +3212,9 @@ class Garmin:
 
         """
         url = f"{self.garmin_golf_user_stats}"
-        logger.debug(
-            "Requesting golf user statistics"
-        )
+        logger.debug("Requesting golf user statistics")
         return self.connectapi(url)
-    
+
 
 from .exceptions import (  # noqa: E402
     GarminConnectAuthenticationError,

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -513,10 +513,6 @@ class Garmin:
             "/lifestylelogging-service/dailyLog"
         )
 
-        self.garmin_connect_daily_lifestyle_jounal_logging_url = (
-            "/lifestyle-journaling-service/journal/dailyReports"
-        )
-
         self.client = client.Client(
             domain="garmin.cn" if is_cn else "garmin.com",
             pool_connections=20,
@@ -1709,14 +1705,6 @@ class Garmin:
         cdate = _validate_date_format(cdate, "cdate")
         url = f"{self.garmin_connect_daily_lifestyle_logging_url}/{cdate}"
         logger.debug("Requesting lifestyle logging data")
-
-        return self.connectapi(url)
-
-    def get_lifestyle_journal_logging_data(self, cdate: str) -> dict[str, Any]:
-        """Return lifestyle jounal logging data for current user."""
-        cdate = _validate_date_format(cdate, "cdate")
-        url = f"{self.garmin_connect_daily_lifestyle_jounal_logging_url}?date={cdate}"
-        logger.debug("Requesting lifestyle journal logging data")
 
         return self.connectapi(url)
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -486,10 +486,11 @@ class Garmin:
             f"{self.garmin_nutrition}/settings"
         )
 
-        self.garmin_golf = "/gcs-golfcommunity/api/v2"
+        self.garmin_ = "/gcs-golfcommunity/api/v2"
         self.garmin_golf_scorecard_summary = f"{self.garmin_golf}/scorecard/summary"
         self.garmin_golf_scorecard_detail = f"{self.garmin_golf}/scorecard/detail"
         self.garmin_golf_shot = f"{self.garmin_golf}/shot/scorecard"
+        self.garmin_golf_club_stats = f"{self.garmin_}/club/player"
 
         self.garmin_connect_delete_activity_url = "/activity-service/activity"
 
@@ -3089,6 +3090,26 @@ class Garmin:
             hole_numbers,
         )
         return self.connectapi(url, params=params)
+        
+    def get_golf_club_stats( 
+        self,
+        limit: int = 1000
+    ) -> dict[str, Any]:
+        """Return golf scorecard summary.
+        Args:
+            limit: Maximum number of results to return.
+
+        Returns:
+            Dictionary containing club list and distance data.
+
+        """
+        url = f"{self.garmin_golf_club_stats}"
+        params = {"per-page": str(limit), "include-stats": "true"}
+        logger.debug(
+            "Requesting golf club data for"
+        )
+        return self.connectapi(url, params=params)
+    
 
 
 from .exceptions import (  # noqa: E402

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -486,11 +486,12 @@ class Garmin:
             f"{self.garmin_nutrition}/settings"
         )
 
-        self.garmin_ = "/gcs-golfcommunity/api/v2"
+        self.garmin_golf = "/gcs-golfcommunity/api/v2"
         self.garmin_golf_scorecard_summary = f"{self.garmin_golf}/scorecard/summary"
         self.garmin_golf_scorecard_detail = f"{self.garmin_golf}/scorecard/detail"
         self.garmin_golf_shot = f"{self.garmin_golf}/shot/scorecard"
-        self.garmin_golf_club_stats = f"{self.garmin_}/club/player"
+        self.garmin_golf_club_stats = f"{self.garmin_golf}/club/player"
+        self.garmin_golf_user_stats = f"{self.garmin_golf}/player/stats"
 
         self.garmin_connect_delete_activity_url = "/activity-service/activity"
 
@@ -500,6 +501,10 @@ class Garmin:
 
         self.garmin_connect_daily_lifestyle_logging_url = (
             "/lifestylelogging-service/dailyLog"
+        )
+
+        self.garmin_connect_daily_lifestyle_jounal_logging_url = (
+            "/lifestyle-journaling-service/journal/dailyReports"
         )
 
         self.client = client.Client(
@@ -1661,6 +1666,15 @@ class Garmin:
         cdate = _validate_date_format(cdate, "cdate")
         url = f"{self.garmin_connect_daily_lifestyle_logging_url}/{cdate}"
         logger.debug("Requesting lifestyle logging data")
+
+        return self.connectapi(url)
+
+    def get_lifestyle_journal_logging_data(self, cdate: str) -> dict[str, Any]:
+        """Return lifestyle jounal logging data for current user."""
+        cdate = _validate_date_format(cdate, "cdate")
+        url = f"{self.garmin_connect_daily_lifestyle_jounal_logging_url}?date={cdate}"
+        print(url)
+        logger.debug("Requesting lifestyle journal logging data")
 
         return self.connectapi(url)
 
@@ -3093,7 +3107,7 @@ class Garmin:
         
     def get_golf_club_stats( 
         self,
-        limit: int = 1000
+        limit: int = 1000,
     ) -> dict[str, Any]:
         """Return golf scorecard summary.
         Args:
@@ -3106,11 +3120,23 @@ class Garmin:
         url = f"{self.garmin_golf_club_stats}"
         params = {"per-page": str(limit), "include-stats": "true"}
         logger.debug(
-            "Requesting golf club data for"
+            "Requesting golf club data for the user."
         )
         return self.connectapi(url, params=params)
     
+    def get_golf_user_stats( self ) -> dict[str, Any]:
+        """Return golf scorecard summary.
 
+        Returns:
+            Dictionary containing club list and distance data.
+
+        """
+        url = f"{self.garmin_golf_user_stats}"
+        logger.debug(
+            "Requesting golf user statistics"
+        )
+        return self.connectapi(url)
+    
 
 from .exceptions import (  # noqa: E402
     GarminConnectAuthenticationError,


### PR DESCRIPTION
Adding two new endpoints for Garmin golf data

- `get_golf_club_stats()`
  - Endpoint: /gcs-golfcommunity/api/v2/club/player
  - Provides details about average distance and club details like shaft type, length, nickname, etc.

- `get_golf_user_stats()`
  - Endpoint: /gcs-golfcommunity/api/v2/player/stats
  - User stats provides summary statistics for the users golf data such as handicap, strokes gained, strokes gained per shot type, rankings among connections, etc. 

All tests & checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access to golf club statistics, including configurable result limits.
  * Added access to an overview of the user’s golf statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->