### PR TITLE
Add date-range variants of get_max_metrics/get_rhr_day/get_hrv_data/get_sleep_data

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -73,6 +73,17 @@ def _validate_date_format(date_str: str, param_name: str = "date") -> str:
     return date_str
 
 
+def _validate_date_range(start: str, end: str) -> tuple[str, str]:
+    """Validate 'start'/'end' are well-formed dates with start <= end."""
+    start = _validate_date_format(start, "start")
+    end = _validate_date_format(end, "end")
+    if datetime.strptime(start, DATE_FORMAT_STR) > datetime.strptime(
+        end, DATE_FORMAT_STR
+    ):
+        raise ValueError("start date cannot be after end date")
+    return start, end
+
+
 def _validate_positive_number(
     value: int | float, param_name: str = "value"
 ) -> int | float:
@@ -1402,13 +1413,13 @@ class Garmin:
         return self.connectapi(url)
 
     def get_max_metrics_range(self, start: str, end: str) -> dict[str, Any]:
-        """Return available max metric data for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+        """Return max metric data for a date range ('start'/'end' format 'YYYY-MM-DD').
 
-        Unlike `get_max_metrics`, which is limited to a single day, this queries
-        the same endpoint with distinct start/end dates to fetch a range in one request.
+        Unlike `get_max_metrics`, which is limited to a single day, this
+        queries the same endpoint with distinct start/end dates to fetch a
+        range in one request.
         """
-        start = _validate_date_format(start, "start")
-        end = _validate_date_format(end, "end")
+        start, end = _validate_date_range(start, end)
         url = f"{self.garmin_connect_metrics_url}/{start}/{end}"
         logger.debug("Requesting max metrics range")
 
@@ -1764,13 +1775,9 @@ class Garmin:
         splits the range into chunks and makes multiple API calls, then merges
         the results, de-duplicating by calendar date.
         """
-        start = _validate_date_format(start, "start")
-        end = _validate_date_format(end, "end")
-
+        start, end = _validate_date_range(start, end)
         start_date = datetime.strptime(start, DATE_FORMAT_STR).date()
         end_date = datetime.strptime(end, DATE_FORMAT_STR).date()
-        if start_date > end_date:
-            raise ValueError("start date cannot be after end date")
 
         results: list[dict[str, Any]] = []
         seen: set[str] = set()
@@ -1828,14 +1835,13 @@ class Garmin:
         return self.connectapi(url, params=params)
 
     def get_rhr_daily(self, start: str, end: str) -> list[dict[str, Any]]:
-        """Return daily resting heart rate for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+        """Return daily resting heart rate for a date range ('start'/'end' format 'YYYY-MM-DD').
 
-        Unlike `get_rhr_day`, which is limited to a single day, this queries the
-        same wellness-stats endpoint with distinct fromDate/untilDate to fetch a
-        range (up to ~1 year) in a single request.
+        Unlike `get_rhr_day`, which is limited to a single day, this queries
+        the same wellness-stats endpoint with distinct fromDate/untilDate to
+        fetch a range (up to ~1 year) in a single request.
         """
-        start = _validate_date_format(start, "start")
-        end = _validate_date_format(end, "end")
+        start, end = _validate_date_range(start, end)
         url = f"{self.garmin_connect_rhr_url}/{self._require_display_name()}"
         params = {
             "fromDate": start,
@@ -1855,14 +1861,13 @@ class Garmin:
         ]
 
     def get_calories_daily(self, start: str, end: str) -> list[dict[str, Any]]:
-        """Return daily active + resting (BMR) calories for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+        """Return daily active + resting (BMR) calories for a date range.
 
-        Uses the same wellness-stats endpoint as `get_rhr_daily` (metric IDs
-        22 = active calories, 23 = BMR calories) to fetch both series for the
-        range in a single request.
+        'start'/'end' format 'YYYY-MM-DD'. Uses the same wellness-stats
+        endpoint as `get_rhr_daily` (metric IDs 22 = active calories, 23 = BMR
+        calories) to fetch both series for the range in a single request.
         """
-        start = _validate_date_format(start, "start")
-        end = _validate_date_format(end, "end")
+        start, end = _validate_date_range(start, end)
         url = f"{self.garmin_connect_rhr_url}/{self._require_display_name()}"
         params = {
             "fromDate": start,
@@ -1908,13 +1913,13 @@ class Garmin:
         return self.connectapi(url)
 
     def get_hrv_data_range(self, start: str, end: str) -> dict[str, Any] | None:
-        """Return HRV (Heart Rate Variability) data for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+        """Return HRV (Heart Rate Variability) data for a date range.
 
-        Unlike `get_hrv_data`, which is limited to a single day, this queries the
-        same endpoint with distinct start/end dates to fetch a range in one request.
+        'start'/'end' format 'YYYY-MM-DD'. Unlike `get_hrv_data`, which is
+        limited to a single day, this queries the same endpoint with distinct
+        start/end dates to fetch a range in one request.
         """
-        start = _validate_date_format(start, "start")
-        end = _validate_date_format(end, "end")
+        start, end = _validate_date_range(start, end)
         url = f"{self.garmin_connect_hrv_url}/daily/{start}/{end}"
         logger.debug("Requesting Heart Rate Variability (hrv) data range")
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1401,6 +1401,19 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def get_max_metrics_range(self, start: str, end: str) -> dict[str, Any]:
+        """Return available max metric data for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+
+        Unlike `get_max_metrics`, which is limited to a single day, this queries
+        the same endpoint with distinct start/end dates to fetch a range in one request.
+        """
+        start = _validate_date_format(start, "start")
+        end = _validate_date_format(end, "end")
+        url = f"{self.garmin_connect_metrics_url}/{start}/{end}"
+        logger.debug("Requesting max metrics range")
+
+        return self.connectapi(url)
+
     def get_lactate_threshold(
         self,
         *,
@@ -1743,6 +1756,48 @@ class Garmin:
 
         return self.connectapi(url, params=params)
 
+    def get_sleep_daily(self, start: str, end: str) -> list[dict[str, Any]]:
+        """Fetch daily sleep summaries for 'start' and 'end' format 'YYYY-MM-DD'.
+
+        Note: The Garmin Connect sleep-stats endpoint has a 28-day limit per
+        request. For date ranges exceeding 28 days, this method automatically
+        splits the range into chunks and makes multiple API calls, then merges
+        the results, de-duplicating by calendar date.
+        """
+        start = _validate_date_format(start, "start")
+        end = _validate_date_format(end, "end")
+
+        start_date = datetime.strptime(start, DATE_FORMAT_STR).date()
+        end_date = datetime.strptime(end, DATE_FORMAT_STR).date()
+        if start_date > end_date:
+            raise ValueError("start date cannot be after end date")
+
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        current_start = start_date
+
+        while current_start <= end_date:
+            chunk_end = min(current_start + timedelta(days=27), end_date)
+            url = (
+                "/sleep-service/stats/sleep/daily/"
+                f"{current_start.isoformat()}/{chunk_end.isoformat()}"
+            )
+            logger.debug(
+                f"Requesting daily sleep data for chunk: "
+                f"{current_start.isoformat()} to {chunk_end.isoformat()}"
+            )
+            data = self.connectapi(url)
+            for row in (data or {}).get("individualStats") or []:
+                cal_date = row.get("calendarDate")
+                if cal_date and cal_date not in seen:
+                    seen.add(cal_date)
+                    results.append(row)
+
+            current_start = chunk_end + timedelta(days=1)
+
+        results.sort(key=lambda r: r.get("calendarDate") or "")
+        return results
+
     def get_stress_data(self, cdate: str) -> dict[str, Any]:
         """Return stress data for 'cdate' format 'YYYY-MM-DD'."""
         cdate = _validate_date_format(cdate, "cdate")
@@ -1772,11 +1827,96 @@ class Garmin:
 
         return self.connectapi(url, params=params)
 
+    def get_rhr_daily(self, start: str, end: str) -> list[dict[str, Any]]:
+        """Return daily resting heart rate for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+
+        Unlike `get_rhr_day`, which is limited to a single day, this queries the
+        same wellness-stats endpoint with distinct fromDate/untilDate to fetch a
+        range (up to ~1 year) in a single request.
+        """
+        start = _validate_date_format(start, "start")
+        end = _validate_date_format(end, "end")
+        url = f"{self.garmin_connect_rhr_url}/{self._require_display_name()}"
+        params = {
+            "fromDate": start,
+            "untilDate": end,
+            "metricId": 60,
+        }
+        logger.debug("Requesting resting heartrate data range")
+
+        data = self.connectapi(url, params=params)
+        rows = ((data or {}).get("allMetrics") or {}).get("metricsMap", {}).get(
+            "WELLNESS_RESTING_HEART_RATE"
+        ) or []
+        return [
+            {"calendarDate": row.get("calendarDate"), "value": row.get("value")}
+            for row in rows
+            if row.get("value") is not None
+        ]
+
+    def get_calories_daily(self, start: str, end: str) -> list[dict[str, Any]]:
+        """Return daily active + resting (BMR) calories for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+
+        Uses the same wellness-stats endpoint as `get_rhr_daily` (metric IDs
+        22 = active calories, 23 = BMR calories) to fetch both series for the
+        range in a single request.
+        """
+        start = _validate_date_format(start, "start")
+        end = _validate_date_format(end, "end")
+        url = f"{self.garmin_connect_rhr_url}/{self._require_display_name()}"
+        params = {
+            "fromDate": start,
+            "untilDate": end,
+            "metricId": [22, 23],
+        }
+        logger.debug("Requesting daily calories data range")
+
+        data = self.connectapi(url, params=params)
+        metrics = ((data or {}).get("allMetrics") or {}).get("metricsMap", {})
+
+        def _by_date(key: str) -> dict[str, float]:
+            return {
+                row.get("calendarDate"): row.get("value")
+                for row in (metrics.get(key) or [])
+                if row.get("calendarDate") is not None and row.get("value") is not None
+            }
+
+        active = _by_date("WELLNESS_ACTIVE_CALORIES")
+        resting = _by_date("WELLNESS_BMR_CALORIES")
+        results: list[dict[str, Any]] = []
+        for cal_date in sorted(set(active) | set(resting)):
+            a = active.get(cal_date)
+            r = resting.get(cal_date)
+            if a is None and r is None:
+                continue
+            results.append(
+                {
+                    "calendarDate": cal_date,
+                    "active": a,
+                    "resting": r,
+                    "total": (a or 0) + (r or 0),
+                }
+            )
+        return results
+
     def get_hrv_data(self, cdate: str) -> dict[str, Any] | None:
         """Return HRV (Heart Rate Variability) data for 'cdate' format 'YYYY-MM-DD'."""
         cdate = _validate_date_format(cdate, "cdate")
         url = f"{self.garmin_connect_hrv_url}/{cdate}"
         logger.debug("Requesting Heart Rate Variability (hrv) data")
+
+        return self.connectapi(url)
+
+    def get_hrv_data_range(self, start: str, end: str) -> dict[str, Any] | None:
+        """Return HRV (Heart Rate Variability) data for a date range, 'start' and 'end' format 'YYYY-MM-DD'.
+
+        Unlike `get_hrv_data`, which is limited to a single day, this queries the
+        same endpoint with distinct start/end dates to fetch a range in one request.
+        """
+        start = _validate_date_format(start, "start")
+        end = _validate_date_format(end, "end")
+        url = f"{self.garmin_connect_hrv_url}/daily/{start}/{end}"
+        logger.debug("Requesting Heart Rate Variability (hrv) data range")
 
         return self.connectapi(url)
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -487,6 +487,28 @@ class TestWellnessDailyRangeMethods:
         with pytest.raises(ValueError, match="start date cannot be after end date"):
             garmin.get_sleep_daily("2026-03-15", "2026-03-01")
 
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "get_max_metrics_range",
+            "get_hrv_data_range",
+            "get_rhr_daily",
+            "get_calories_daily",
+            "get_sleep_daily",
+        ],
+    )
+    def test_range_methods_reject_inverted_range_without_api_call(
+        self, garmin: garminconnect.Garmin, method_name: str
+    ):
+        """All *_range/*_daily methods must reject start > end before calling the API."""
+        method = getattr(garmin, method_name)
+        with (
+            patch.object(garmin, "connectapi") as mock,
+            pytest.raises(ValueError, match="start date cannot be after end date"),
+        ):
+            method("2026-03-15", "2026-03-01")
+        mock.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Parameter limit tests

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -341,6 +341,154 @@ class TestUrlConstruction:
 
 
 # ---------------------------------------------------------------------------
+# Date-range wellness method tests (max metrics, RHR, calories, sleep, HRV)
+# ---------------------------------------------------------------------------
+
+
+class TestWellnessDailyRangeMethods:
+    """URL/param construction and chunking for the *_daily / *_range wellness methods."""
+
+    def test_get_max_metrics_range_builds_url_with_distinct_dates(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value={"vo2Max": 55}) as mock:
+            result = garmin.get_max_metrics_range("2026-03-01", "2026-03-15")
+
+        url = mock.call_args[0][0]
+        assert url.endswith(
+            "/metrics-service/metrics/maxmet/daily/2026-03-01/2026-03-15"
+        )
+        assert result == {"vo2Max": 55}
+
+    def test_get_max_metrics_range_rejects_malformed_date(
+        self, garmin: garminconnect.Garmin
+    ):
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            garmin.get_max_metrics_range("not-a-date", "2026-03-15")
+
+    def test_get_hrv_data_range_builds_url_with_distinct_dates(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(
+            garmin, "connectapi", return_value={"hrvSummaries": []}
+        ) as mock:
+            result = garmin.get_hrv_data_range("2026-03-01", "2026-03-15")
+
+        url = mock.call_args[0][0]
+        assert url.endswith("/hrv-service/hrv/daily/2026-03-01/2026-03-15")
+        assert result == {"hrvSummaries": []}
+
+    def test_get_rhr_daily_builds_url_and_filters_metric_map(
+        self, garmin: garminconnect.Garmin
+    ):
+        payload = {
+            "allMetrics": {
+                "metricsMap": {
+                    "WELLNESS_RESTING_HEART_RATE": [
+                        {"calendarDate": "2026-03-01", "value": 52},
+                        {"calendarDate": "2026-03-02", "value": None},
+                    ]
+                }
+            }
+        }
+        with patch.object(garmin, "connectapi", return_value=payload) as mock:
+            result = garmin.get_rhr_daily("2026-03-01", "2026-03-02")
+
+        url, kwargs = mock.call_args[0][0], mock.call_args[1]
+        assert url.endswith("/userstats-service/wellness/daily/test-display")
+        assert kwargs["params"] == {
+            "fromDate": "2026-03-01",
+            "untilDate": "2026-03-02",
+            "metricId": 60,
+        }
+        # Rows with a null value are dropped.
+        assert result == [{"calendarDate": "2026-03-01", "value": 52}]
+
+    def test_get_rhr_daily_rejects_malformed_date(self, garmin: garminconnect.Garmin):
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            garmin.get_rhr_daily("not-a-date", "2026-03-02")
+
+    def test_get_calories_daily_merges_active_and_resting(
+        self, garmin: garminconnect.Garmin
+    ):
+        payload = {
+            "allMetrics": {
+                "metricsMap": {
+                    "WELLNESS_ACTIVE_CALORIES": [
+                        {"calendarDate": "2026-03-01", "value": 400},
+                    ],
+                    "WELLNESS_BMR_CALORIES": [
+                        {"calendarDate": "2026-03-01", "value": 1600},
+                        {"calendarDate": "2026-03-02", "value": 1500},
+                    ],
+                }
+            }
+        }
+        with patch.object(garmin, "connectapi", return_value=payload) as mock:
+            result = garmin.get_calories_daily("2026-03-01", "2026-03-02")
+
+        kwargs = mock.call_args[1]
+        assert kwargs["params"]["metricId"] == [22, 23]
+        assert result == [
+            {
+                "calendarDate": "2026-03-01",
+                "active": 400,
+                "resting": 1600,
+                "total": 2000,
+            },
+            {
+                "calendarDate": "2026-03-02",
+                "active": None,
+                "resting": 1500,
+                "total": 1500,
+            },
+        ]
+
+    def test_get_sleep_daily_single_chunk_dedupes_and_sorts(
+        self, garmin: garminconnect.Garmin
+    ):
+        payload = {
+            "individualStats": [
+                {"calendarDate": "2026-03-02", "overallSleepScore": 80},
+                {"calendarDate": "2026-03-01", "overallSleepScore": 75},
+                {"calendarDate": "2026-03-01", "overallSleepScore": 75},
+            ]
+        }
+        with patch.object(garmin, "connectapi", return_value=payload) as mock:
+            result = garmin.get_sleep_daily("2026-03-01", "2026-03-02")
+
+        mock.assert_called_once()
+        url = mock.call_args[0][0]
+        assert url.endswith("/sleep-service/stats/sleep/daily/2026-03-01/2026-03-02")
+        assert [row["calendarDate"] for row in result] == ["2026-03-01", "2026-03-02"]
+
+    def test_get_sleep_daily_chunks_ranges_over_28_days(
+        self, garmin: garminconnect.Garmin
+    ):
+        # 30-day range should be split into two requests (28 days + 2 days).
+        with patch.object(
+            garmin, "connectapi", return_value={"individualStats": []}
+        ) as mock:
+            garmin.get_sleep_daily("2026-01-01", "2026-01-30")
+
+        assert mock.call_count == 2
+        first_url = mock.call_args_list[0][0][0]
+        second_url = mock.call_args_list[1][0][0]
+        assert first_url.endswith(
+            "/sleep-service/stats/sleep/daily/2026-01-01/2026-01-28"
+        )
+        assert second_url.endswith(
+            "/sleep-service/stats/sleep/daily/2026-01-29/2026-01-30"
+        )
+
+    def test_get_sleep_daily_rejects_start_after_end(
+        self, garmin: garminconnect.Garmin
+    ):
+        with pytest.raises(ValueError, match="start date cannot be after end date"):
+            garmin.get_sleep_daily("2026-03-15", "2026-03-01")
+
+
+# ---------------------------------------------------------------------------
 # Parameter limit tests
 # ---------------------------------------------------------------------------
 
@@ -656,9 +804,7 @@ class TestHttpErrorMapping:
 class TestUpdateWorkout:
     """``update_workout`` PUTs the full workout to /workout-service/workout/<id>."""
 
-    def test_puts_to_workout_url_with_injected_id(
-        self, garmin: garminconnect.Garmin
-    ):
+    def test_puts_to_workout_url_with_injected_id(self, garmin: garminconnect.Garmin):
         workout = {"workoutName": "Edited", "sportType": {"sportTypeId": 1}}
         with patch.object(garmin, "client") as client:
             client.put.return_value = {"workoutId": 123, "workoutName": "Edited"}
@@ -672,9 +818,7 @@ class TestUpdateWorkout:
         assert kwargs["json"]["workoutName"] == "Edited"
         assert result == {"workoutId": 123, "workoutName": "Edited"}
 
-    def test_injected_id_overrides_stray_workout_id(
-        self, garmin: garminconnect.Garmin
-    ):
+    def test_injected_id_overrides_stray_workout_id(self, garmin: garminconnect.Garmin):
         workout = {"workoutId": 999, "workoutName": "Edited"}
         with patch.object(garmin, "client") as client:
             garmin.update_workout(123, workout)


### PR DESCRIPTION
## Summary

Several single-day methods call Garmin endpoints that natively support a date range, but hardcode `fromDate = untilDate = cdate`, forcing callers who want history into N single-day requests:

- `get_max_metrics(cdate)` → `.../metrics-service/metrics/maxmet/daily/{cdate}/{cdate}`
- `get_rhr_day(cdate)` → `.../userstats-service/wellness/daily/{display_name}` with `fromDate=untilDate=cdate`
- `get_hrv_data(cdate)` → `.../hrv-service/hrv/{cdate}` (range form lives at `.../hrv-service/hrv/daily/{start}/{end}`)
- `get_sleep_data(cdate)` → single-night detail only; no daily-summary-range equivalent exists

This PR adds range-capable siblings rather than changing existing signatures, so nothing breaks:

- `get_max_metrics_range(start, end)`
- `get_hrv_data_range(start, end)`
- `get_rhr_daily(start, end)` — same wellness-stats endpoint as `get_rhr_day`, filtered down to the `WELLNESS_RESTING_HEART_RATE` series
- `get_sleep_daily(start, end)` — daily sleep summaries over a range, chunked to the sleep-stats endpoint's 28-day cap (same pattern already used by `get_daily_steps` for its own 28-day limit)
- `get_calories_daily(start, end)` — new method (no existing calories wrapper), reuses the same wellness-stats endpoint as `get_rhr_daily` with `metricId=[22, 23]` for active/BMR calories

I verified the underlying endpoint paths/params against a live Garmin account before writing this (not just guessed from adjacent code), then re-confirmed each one against this repo's own already-merged patterns (`get_daily_steps`'s chunking, `get_lactate_threshold`'s range-vs-latest split) to keep the style consistent.

## Test plan

- [x] `pytest tests -m "not integration"` — 201 passed (was 192, +9 new)
- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] New unit tests cover: URL/param construction for each new method, RHR/calories metricsMap filtering (including null-value rows dropped), sleep single-chunk dedup+sort, sleep multi-chunk splitting across the 28-day boundary, and date-order/format validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date-range queries for maximum metrics and HRV data.
  * Added daily range retrieval for sleep, resting heart rate, and calories.
  * Calories are now returned with per-date active, resting, and total values.
* **Bug Fixes**
  * Improved handling of malformed or inverted date ranges by validating `start`/`end` inputs.
  * Resting heart rate results now omit entries with missing metric values.
  * Sleep data is deduplicated, sorted by date, and split into API-friendly range chunks.
* **Tests**
  * Expanded unit test coverage for range methods, merging behavior, filtering, chunking, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->