### PR TITLE
Add date-range FTP retrieval

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1425,6 +1425,51 @@ class Garmin:
 
         return self.connectapi(url)
 
+    def get_functional_threshold_power_range(
+        self,
+        start_date: str | date,
+        end_date: str | date | None = None,
+        *,
+        sport: str = "RUNNING",
+        aggregation: str = "daily",
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """Return historic functional threshold power for a Garmin sport.
+
+        This uses Garmin Connect's undocumented biometric statistics range
+        endpoint.  It is useful for FTP history because the existing
+        ``get_cycling_ftp`` endpoint returns only the latest cycling value.
+        """
+        if isinstance(start_date, date):
+            normalized_start_date = start_date.isoformat()
+        else:
+            normalized_start_date = _validate_date_format(start_date, "start_date")
+        if end_date is None:
+            normalized_end_date = date.today().isoformat()
+        elif isinstance(end_date, date):
+            normalized_end_date = end_date.isoformat()
+        else:
+            normalized_end_date = _validate_date_format(end_date, "end_date")
+        if normalized_start_date > normalized_end_date:
+            raise ValueError("start_date must be on or before end_date")
+
+        valid_aggregations = {"daily", "weekly", "monthly", "yearly"}
+        if aggregation not in valid_aggregations:
+            raise ValueError(f"aggregation must be one of {valid_aggregations}")
+
+        normalized_sport = _validate_sport_key(sport)
+        url = (
+            f"{self.garmin_connect_biometric_stats_url}"
+            f"/functionalThresholdPower/range/{normalized_start_date}/{normalized_end_date}"
+            f"?sport={normalized_sport}&aggregation={aggregation}&aggregationStrategy=LATEST"
+        )
+        logger.debug(
+            "Requesting functional threshold power from %s to %s for sport %s",
+            normalized_start_date,
+            normalized_end_date,
+            normalized_sport,
+        )
+        return self.connectapi(url)
+
     def get_lactate_threshold(
         self,
         *,
@@ -1516,11 +1561,14 @@ class Garmin:
 
         heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
 
-        power_url = f"{self.garmin_connect_biometric_stats_url}/functionalThresholdPower/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
-
         speed = self.connectapi(speed_url)
         heart_rate = self.connectapi(heart_rate_url)
-        power = self.connectapi(power_url)
+        power = self.get_functional_threshold_power_range(
+            start_date,
+            end_date,
+            sport="RUNNING",
+            aggregation=aggregation,
+        )
 
         return {"speed": speed, "heart_rate": heart_rate, "power": power}
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1439,12 +1439,16 @@ class Garmin:
         endpoint.  It is useful for FTP history because the existing
         ``get_cycling_ftp`` endpoint returns only the latest cycling value.
         """
-        if isinstance(start_date, date):
+        if isinstance(start_date, datetime):
+            normalized_start_date = start_date.date().isoformat()
+        elif isinstance(start_date, date):
             normalized_start_date = start_date.isoformat()
         else:
             normalized_start_date = _validate_date_format(start_date, "start_date")
         if end_date is None:
             normalized_end_date = date.today().isoformat()
+        elif isinstance(end_date, datetime):
+            normalized_end_date = end_date.date().isoformat()
         elif isinstance(end_date, date):
             normalized_end_date = end_date.isoformat()
         else:
@@ -1557,18 +1561,19 @@ class Garmin:
         if aggregation not in _valid_aggregations:
             raise ValueError(f"aggregation must be one of {_valid_aggregations}")
 
-        speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
-
-        heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
-
-        speed = self.connectapi(speed_url)
-        heart_rate = self.connectapi(heart_rate_url)
         power = self.get_functional_threshold_power_range(
             start_date,
             end_date,
             sport="RUNNING",
             aggregation=aggregation,
         )
+
+        speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+
+        heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+
+        speed = self.connectapi(speed_url)
+        heart_rate = self.connectapi(heart_rate_url)
 
         return {"speed": speed, "heart_rate": heart_rate, "power": power}
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1568,9 +1568,17 @@ class Garmin:
             aggregation=aggregation,
         )
 
-        speed_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdSpeed/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        speed_url = (
+            f"{self.garmin_connect_biometric_stats_url}"
+            f"/lactateThresholdSpeed/range/{start_date}/{end_date}"
+            f"?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        )
 
-        heart_rate_url = f"{self.garmin_connect_biometric_stats_url}/lactateThresholdHeartRate/range/{start_date}/{end_date}?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        heart_rate_url = (
+            f"{self.garmin_connect_biometric_stats_url}"
+            f"/lactateThresholdHeartRate/range/{start_date}/{end_date}"
+            f"?sport=RUNNING&aggregation={aggregation}&aggregationStrategy=LATEST"
+        )
 
         speed = self.connectapi(speed_url)
         heart_rate = self.connectapi(heart_rate_url)

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -16,6 +16,7 @@ Run with:
     python -m pytest tests/test_garmin_unit.py -v
 """
 
+from datetime import date
 from unittest.mock import patch
 
 import pytest
@@ -177,6 +178,78 @@ class TestUrlConstruction:
         assert url.endswith(
             "/metrics-service/metrics/maxmet/daily/2026-03-15/2026-03-15"
         )
+
+    def test_get_functional_threshold_power_range_builds_cycling_url(
+        self, garmin: garminconnect.Garmin
+    ):
+        payload = [{"series": "cycling", "value": 255}]
+        with patch.object(garmin, "connectapi", return_value=payload) as mock:
+            result = garmin.get_functional_threshold_power_range(
+                "2025-06-01", "2025-06-30", sport=" cycling "
+            )
+
+        mock.assert_called_once_with(
+            "/biometric-service/stats/functionalThresholdPower/range/2025-06-01/2025-06-30"
+            "?sport=CYCLING&aggregation=daily&aggregationStrategy=LATEST"
+        )
+        assert result == payload
+
+    def test_get_max_metrics_range_builds_distinct_date_url(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value=[]) as mock:
+            garmin.get_max_metrics_range("2026-03-01", "2026-03-15")
+        assert mock.call_args[0][0].endswith(
+            "/metrics-service/metrics/maxmet/daily/2026-03-01/2026-03-15"
+        )
+
+    def test_get_hrv_data_range_builds_distinct_date_url(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value={}) as mock:
+            garmin.get_hrv_data_range("2026-03-01", "2026-03-15")
+        assert mock.call_args[0][0].endswith(
+            "/hrv-service/hrv/daily/2026-03-01/2026-03-15"
+        )
+
+    @pytest.mark.parametrize("method_name", ["get_max_metrics_range", "get_hrv_data_range"])
+    def test_new_range_methods_reject_inverted_dates(
+        self, garmin: garminconnect.Garmin, method_name: str
+    ):
+        with pytest.raises(ValueError, match="start date cannot be after end date"):
+            getattr(garmin, method_name)("2026-03-15", "2026-03-01")
+
+    def test_get_functional_threshold_power_range_accepts_dates(
+        self, garmin: garminconnect.Garmin
+    ):
+        with patch.object(garmin, "connectapi", return_value=[]) as mock:
+            garmin.get_functional_threshold_power_range(
+                date(2025, 6, 1), date(2025, 6, 30), sport="RUNNING", aggregation="weekly"
+            )
+
+        assert "sport=RUNNING&aggregation=weekly" in mock.call_args[0][0]
+
+    @pytest.mark.parametrize(
+        ("start_date", "end_date", "sport", "aggregation", "message"),
+        [
+            ("2025-06-30", "2025-06-01", "CYCLING", "daily", "start_date"),
+            ("2025-06-01", "2025-06-30", "cycling/running", "daily", "sport must"),
+            ("2025-06-01", "2025-06-30", "CYCLING", "hourly", "aggregation"),
+        ],
+    )
+    def test_get_functional_threshold_power_range_validates_parameters(
+        self,
+        garmin: garminconnect.Garmin,
+        start_date: str,
+        end_date: str,
+        sport: str,
+        aggregation: str,
+        message: str,
+    ):
+        with pytest.raises(ValueError, match=message):
+            garmin.get_functional_threshold_power_range(
+                start_date, end_date, sport=sport, aggregation=aggregation
+            )
 
     def test_get_fitnessage_data_builds_url_with_date(
         self, garmin: garminconnect.Garmin

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -212,7 +212,9 @@ class TestUrlConstruction:
             "/hrv-service/hrv/daily/2026-03-01/2026-03-15"
         )
 
-    @pytest.mark.parametrize("method_name", ["get_max_metrics_range", "get_hrv_data_range"])
+    @pytest.mark.parametrize(
+        "method_name", ["get_max_metrics_range", "get_hrv_data_range"]
+    )
     def test_new_range_methods_reject_inverted_dates(
         self, garmin: garminconnect.Garmin, method_name: str
     ):
@@ -224,7 +226,10 @@ class TestUrlConstruction:
     ):
         with patch.object(garmin, "connectapi", return_value=[]) as mock:
             garmin.get_functional_threshold_power_range(
-                date(2025, 6, 1), date(2025, 6, 30), sport="RUNNING", aggregation="weekly"
+                date(2025, 6, 1),
+                date(2025, 6, 30),
+                sport="RUNNING",
+                aggregation="weekly",
             )
 
         assert "sport=RUNNING&aggregation=weekly" in mock.call_args[0][0]

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -16,7 +16,7 @@ Run with:
     python -m pytest tests/test_garmin_unit.py -v
 """
 
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import patch
 
 import pytest
@@ -255,6 +255,34 @@ class TestUrlConstruction:
             garmin.get_functional_threshold_power_range(
                 start_date, end_date, sport=sport, aggregation=aggregation
             )
+
+    def test_get_lactate_threshold_rejects_inverted_range(
+        self, garmin: garminconnect.Garmin
+    ):
+        with (
+            patch.object(garmin, "connectapi") as mock_connectapi,
+            patch.object(
+                garmin,
+                "get_functional_threshold_power_range",
+                side_effect=ValueError("start_date must be on or before end_date"),
+            ) as mock_ftp,
+        ):
+            with pytest.raises(
+                ValueError, match="start_date must be on or before end_date"
+            ):
+                garmin.get_lactate_threshold(
+                    latest=False,
+                    start_date="2025-06-30",
+                    end_date="2025-06-01",
+                )
+
+        mock_ftp.assert_called_once_with(
+            "2025-06-30",
+            "2025-06-01",
+            sport="RUNNING",
+            aggregation="daily",
+        )
+        mock_connectapi.assert_not_called()
 
     def test_get_fitnessage_data_builds_url_with_date(
         self, garmin: garminconnect.Garmin


### PR DESCRIPTION
## Summary

`get_cycling_ftp()` returns only the latest cycling FTP value, while `get_lactate_threshold(latest=False)` already calls Garmin's undocumented historical FTP range endpoint inline. That makes FTP history unavailable as a direct public API and duplicates the endpoint construction.

This PR adds a range-capable sibling:

- `get_functional_threshold_power_range(start_date, end_date=None, *, sport="RUNNING", aggregation="daily")`
- accepts ISO date strings or `date` objects; `end_date` defaults to today
- validates date order, supported sport keys, and aggregation values
- calls `/biometric-service/stats/functionalThresholdPower/range/{start}/{end}` with Garmin's required `sport`, `aggregation`, and `aggregationStrategy=LATEST` parameters
- normalizes sport values consistently with the existing sport-key helpers

`get_lactate_threshold(latest=False)` now reuses this method for its power result, removing the duplicated endpoint construction without changing its returned structure or latest-value behavior.

`get_cycling_ftp()` remains unchanged for callers that only need the current cycling FTP.

## Test plan

- [x] `pdm run test`: 215 passed, 18 integration tests deselected
- [x] New unit tests cover:
  - cycling URL and normalized sport construction
  - `date` object inputs and non-default aggregation
  - inverted date ranges
  - unsupported sport keys and aggregation values

Verified against a live Garmin account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functional threshold power retrieval for a specific date or date range.
  - Supports date and datetime inputs, sport selection, and daily or weekly aggregation.
  - Added validation for date ranges, sport values, and aggregation options.

- **Bug Fixes**
  - Improved lactate-threshold range retrieval with consistent functional threshold power handling.
  - Enhanced validation for reversed date ranges and health metric requests.
  - Improved reliability when retrieving maximum metrics and heart-rate variability data over date ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->