### PR TITLE
security: validate JWT exp claim to prevent client DoS

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -13,6 +13,7 @@ import contextlib
 import http.cookiejar
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -1315,11 +1316,17 @@ class Client:
         if not payload:
             return False
         # 'exp' is a server-controlled claim from an unverified JWT payload, so
-        # coerce it defensively: a non-numeric string or container must not
-        # raise (ValueError/TypeError) and take down every request.
+        # coerce it defensively: a non-numeric string, container, boolean,
+        # non-finite or overflowing value must not raise (TypeError/ValueError/
+        # OverflowError) and take down every request.
+        raw_exp = payload.get("exp")
+        if isinstance(raw_exp, bool):
+            return False
         try:
-            exp = float(payload.get("exp"))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
+            exp = float(raw_exp)  # type: ignore[arg-type]
+        except (TypeError, ValueError, OverflowError):
+            return False
+        if not math.isfinite(exp):
             return False
         return time.time() > exp - 900
 

--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -1314,8 +1314,14 @@ class Client:
         payload = _decode_jwt_payload(str(token))
         if not payload:
             return False
-        exp = payload.get("exp")
-        return bool(exp and time.time() > int(exp) - 900)
+        # 'exp' is a server-controlled claim from an unverified JWT payload, so
+        # coerce it defensively: a non-numeric string or container must not
+        # raise (ValueError/TypeError) and take down every request.
+        try:
+            exp = float(payload.get("exp"))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return False
+        return time.time() > exp - 900
 
     def _refresh_session(self) -> None:
         """Refresh auth — DI token refresh or legacy JWT_WEB CAS refresh."""

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -1740,6 +1740,36 @@ class TestJwtHandling:
         c.jwt_web = token
         assert c._token_expires_soon() is True
 
+    def test_token_expires_soon_accepts_numeric_string_exp(self):
+        # Some tokens encode 'exp' as a numeric string; it must still parse.
+        c = client_mod.Client(verify_login=False)
+        token = _make_jwt(
+            {"alg": "RS256"}, {"exp": str(int(time.time()) + 60)}
+        )
+        c.di_token = token
+        assert c._token_expires_soon() is True
+
+    @pytest.mark.parametrize(
+        "exp",
+        [
+            "not-a-number",  # non-numeric string -> would raise ValueError
+            {"a": 1},        # non-empty dict     -> would raise TypeError
+            [1],             # non-empty list     -> would raise TypeError
+            None,            # missing / null
+            "",              # empty string
+            {},              # empty dict
+            [],              # empty list
+        ],
+    )
+    def test_token_expires_soon_survives_malformed_exp(self, exp: Any):
+        # A hostile/MITM server can return an access token whose unverified
+        # 'exp' claim is non-numeric. int()/float() coercion must not raise and
+        # take down every subsequent request. Malformed 'exp'
+        # is treated as "not expiring soon" so the client stays usable.
+        c = client_mod.Client(verify_login=False)
+        c.di_token = _make_jwt({"alg": "RS256"}, {"exp": exp})
+        assert c._token_expires_soon() is False
+
 
 # ---------------------------------------------------------------------------
 # update_workout (in-place PUT)

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -1759,13 +1759,20 @@ class TestJwtHandling:
             "",              # empty string
             {},              # empty dict
             [],              # empty list
+            True,            # bool is an int subclass; must be rejected
+            False,
+            "inf",           # non-finite string  -> parses, must be rejected
+            "-inf",
+            "nan",
+            10**400,         # huge JSON int      -> would raise OverflowError
         ],
     )
     def test_token_expires_soon_survives_malformed_exp(self, exp: Any):
         # A hostile/MITM server can return an access token whose unverified
-        # 'exp' claim is non-numeric. int()/float() coercion must not raise and
-        # take down every subsequent request. Malformed 'exp'
-        # is treated as "not expiring soon" so the client stays usable.
+        # 'exp' claim is non-numeric, boolean, non-finite or overflowing.
+        # int()/float() coercion must not raise and take down every
+        # subsequent request. Malformed 'exp' is treated as "not expiring
+        # soon" so the client stays usable.
         c = client_mod.Client(verify_login=False)
         c.di_token = _make_jwt({"alg": "RS256"}, {"exp": exp})
         assert c._token_expires_soon() is False


### PR DESCRIPTION
## Summary

Fixes a client-side denial-of-service reported externally (CVSS 4.0 8.2 / High).

`_token_expires_soon()` called `int(exp)` on the `exp` claim taken directly from `_decode_jwt_payload()` — an **unverified, server-controlled** JWT payload — with no type guard anywhere in the chain.

`int(exp)` raises:
- `ValueError` for a non-numeric string (e.g. `"not-a-number"`)
- `TypeError` for a non-empty container (e.g. `{"a": 1}`, `[1]`)

### Impact
- A hostile / compromised / MITM server returning a crafted `access_token` poisons `self.di_token`. Every public method routed through `_run_request` (get/post/download/connectapi/…) then raised the raw exception **before** any HTTP request.
- The exception is **not** a `GarminConnect*` subclass, so callers catching by library type don't handle it — can crash the host app.
- The poisoned token is persisted by `dump()` / restored by `load()`, so a single crafted response leaves the client **unusable across restarts** until the token file is manually deleted.

## Fix

Coerce `exp` with `float()` inside a `try/except (TypeError, ValueError)`, returning `False` (treat as "not expiring soon", client stays usable) when it can't be parsed. This also transparently supports legitimate numeric-string `exp` values. A genuinely expired token is still caught by the normal 401 path.

## Tests

Added to `tests/test_garmin_unit.py::TestJwtHandling`:
- `test_token_expires_soon_accepts_numeric_string_exp`
- `test_token_expires_soon_survives_malformed_exp` — parametrized over `"not-a-number"`, `{"a":1}`, `[1]`, `None`, `""`, `{}`, `[]`

15/15 JWT tests pass; no regressions in the unit suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or missing token expiration values.
  * Prevented errors when expiration data is non-numeric, empty, null, boolean, non-finite, overflowing, or provided in an unexpected format.
  * Numeric-string expiration timestamps are now processed correctly.
  * Correctly identifies tokens with expired or zero-valued expiration timestamps.
  * Maintained the existing 15-minute warning threshold for valid expiration timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
