### PR TITLE
security: cap server-driven pagination to prevent client DoS

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -39,6 +39,12 @@ _STATUS_CODE_RE = re.compile(r"(?:API Error|Error|HTTP)\s*(\d{3})")
 # Constants for validation
 MAX_ACTIVITY_LIMIT = 1000
 MAX_HYDRATION_ML = 10000  # 10 liters
+# Safety cap on server-driven pagination loops (get_activities_by_date,
+# get_goals). Termination of those loops otherwise depends entirely on the
+# server eventually returning an empty page, so a hostile/broken server could
+# loop the client forever with unbounded memory growth. 2000 pages at 20-30
+# items per page (40k-60k items) is far beyond any legitimate account.
+MAX_PAGINATED_REQUESTS = 2000
 DATE_FORMAT_REGEX = r"^\d{4}-\d{2}-\d{2}$"
 DATE_FORMAT_STR = "%Y-%m-%d"
 
@@ -2639,7 +2645,7 @@ class Garmin:
             params["sortOrder"] = sortorder
 
         logger.debug("Requesting activities by date from %s to %s", startdate, enddate)
-        while True:
+        for _ in range(MAX_PAGINATED_REQUESTS):
             params["start"] = str(start)
             logger.debug("Requesting activities %d to %d", start, start + limit)
             act = self.connectapi(url, params=params)
@@ -2648,6 +2654,12 @@ class Garmin:
                 start = start + limit
             else:
                 break
+        else:
+            # A server that never returns an empty page would otherwise loop
+            # the client forever (DoS); fail loudly instead of truncating.
+            raise GarminConnectConnectionError(
+                f"Pagination exceeded {MAX_PAGINATED_REQUESTS} requests; aborting"
+            )
 
         return activities
 
@@ -2714,7 +2726,7 @@ class Garmin:
         }
 
         logger.debug("Requesting %s goals", status)
-        while True:
+        for _ in range(MAX_PAGINATED_REQUESTS):
             params["start"] = str(start)
             logger.debug(
                 "Requesting %s goals %d to %d", status, start, start + limit - 1
@@ -2725,6 +2737,12 @@ class Garmin:
                 start = start + limit
             else:
                 break
+        else:
+            # A server that never returns an empty page would otherwise loop
+            # the client forever (DoS); fail loudly instead of truncating.
+            raise GarminConnectConnectionError(
+                f"Pagination exceeded {MAX_PAGINATED_REQUESTS} requests; aborting"
+            )
 
         return goals
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -1573,6 +1573,28 @@ class TestResponseHandling:
 
         assert mock.call_count == garminconnect.MAX_PAGINATED_REQUESTS
 
+    def test_get_goals_paginates_until_empty(self, garmin: garminconnect.Garmin):
+        # Normal termination: two non-empty pages followed by an empty page
+        # must complete successfully and advance start by limit each page.
+        # (params is mutated between calls, so snapshot start at call time.)
+        starts: list[str] = []
+        pages = [
+            [{"goalId": i} for i in range(30)],
+            [{"goalId": i + 30} for i in range(10)],
+            [],
+        ]
+
+        def fake_connectapi(url, params=None):
+            starts.append(params["start"])
+            return pages.pop(0)
+
+        with patch.object(garmin, "connectapi", side_effect=fake_connectapi) as mock:
+            result = garmin.get_goals()
+
+        assert len(result) == 40
+        assert mock.call_count == 3
+        assert starts == ["0", "30", "60"]
+
 
 # ---------------------------------------------------------------------------
 # _run_request: HTTP status -> exception mapping

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -1545,6 +1545,34 @@ class TestResponseHandling:
         assert last_params["startDate"] == "2026-03-01"
         assert last_params["endDate"] == "2026-03-31"
 
+    def test_get_activities_by_date_pagination_is_capped(
+        self, garmin: garminconnect.Garmin
+    ):
+        # A hostile server that never returns an empty page must not be able
+        # to loop the client forever.
+        with (
+            patch.object(garmin, "connectapi", return_value=[{}]) as mock,
+            pytest.raises(
+                garminconnect.GarminConnectConnectionError,
+                match="Pagination exceeded",
+            ),
+        ):
+            garmin.get_activities_by_date("2026-03-01", "2026-03-31")
+
+        assert mock.call_count == garminconnect.MAX_PAGINATED_REQUESTS
+
+    def test_get_goals_pagination_is_capped(self, garmin: garminconnect.Garmin):
+        with (
+            patch.object(garmin, "connectapi", return_value=[{}]) as mock,
+            pytest.raises(
+                garminconnect.GarminConnectConnectionError,
+                match="Pagination exceeded",
+            ),
+        ):
+            garmin.get_goals()
+
+        assert mock.call_count == garminconnect.MAX_PAGINATED_REQUESTS
+
 
 # ---------------------------------------------------------------------------
 # _run_request: HTTP status -> exception mapping


### PR DESCRIPTION
## Summary

Fixes a client-side denial-of-service from an external security audit (report 3995's sibling, report 3993, CVSS 4.0 8.2 / High).

`get_activities_by_date()` and `get_goals()` paginated with `while True:` and broke only when the server returned an empty (falsy) page. There was no cap on page count, total rows, or the `start` offset — loop termination depended **entirely on the server**.

## Impact

A hostile / compromised / MITM server that returns a non-empty page for every `start` offset hangs the embedding application indefinitely with unbounded memory growth (report PoC: ~3.2M iterations and 3.2M+ accumulated list items in 5 seconds; eventual OOM). Availability only — no confidentiality/integrity impact.

The other `while True:` loops in the package (`fit.py`) iterate over a local `BytesIO` and are bounded; `get_activities` is already caller-bounded by `limit`. Only these two paginators were affected.

## Fix

New module constant `MAX_PAGINATED_REQUESTS = 2000` (at 20–30 items/page that is 40k–60k items — far beyond any legitimate account). Both loops are now bounded `for _ in range(MAX_PAGINATED_REQUESTS)` with a `for`/`else` that raises `GarminConnectConnectionError("Pagination exceeded …")` when the cap is hit — failing loudly rather than silently truncating, since a server feeding that many pages is hostile or broken and the data would be suspect anyway. Normal termination (empty page → `break`) is unchanged.

## Tests

- `test_get_activities_by_date_pagination_is_capped` — never-empty server → raises `GarminConnectConnectionError` after exactly `MAX_PAGINATED_REQUESTS` calls
- `test_get_goals_pagination_is_capped` — same for goals
- Existing `test_get_activities_by_date_paginates_until_empty` still passes (normal termination unchanged)

Full suite: 261 passed; the 13 `test_workout_constants` failures and the `test_typed.py` import error (missing optional `pydantic`) are pre-existing — verified identical on a clean tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard to prevent activity and goal retrieval from running indefinitely when the service returns continuous paginated results.
  * Requests now stop after a defined limit and report a connection error when pagination cannot complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
