### PR TITLE
security: clear stale auth state at login entry

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -305,14 +305,20 @@ class Client:
     def is_authenticated(self) -> bool:
         return bool(self.di_token or self.jwt_web)
 
-    def _clear_auth_state(self) -> None:
-        """Wipe all in-memory auth tokens and session state so the next login starts clean."""
+    def _clear_auth_state(self, *, keep_tokenstore_path: bool = False) -> None:
+        """Wipe all in-memory auth tokens and session state so the next login starts clean.
+
+        ``keep_tokenstore_path`` preserves the persistence target: login() sets
+        it via the Garmin wrapper *before* the credential flow runs, and a
+        fresh login should keep persisting to the same store.
+        """
         self.di_token = None
         self.di_refresh_token = None
         self.di_client_id = None
         self.jwt_web = None
         self.csrf_token = None
-        self._tokenstore_path = None
+        if not keep_tokenstore_path:
+            self._tokenstore_path = None
         self._mfa_pending = False
         for attr in (
             "_mfa_session",
@@ -408,6 +414,14 @@ class Client:
                 "MFA login already in progress; complete it with resume_login() "
                 "or call logout() first"
             )
+
+        # Start every credential login from a clean slate. A stale di_token
+        # from a previous login/token-load must not survive this call: it
+        # would keep is_authenticated True after all strategies fail, and
+        # get_api_headers() prefers di_token, so it would silently shadow a
+        # fresh jwt_web obtained by a web strategy (and _verify_token would
+        # then "verify" the old identity instead of the new login).
+        self._clear_auth_state(keep_tokenstore_path=True)
 
         strategies: list[tuple[str, Any]] = [
             ("mobile+cffi", lambda: self._mobile_login_cffi(email, password)),

--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -450,7 +450,7 @@ class Client:
                 mfa_code = prompt_mfa()
                 self._complete_mfa(mfa_code)
                 if self.verify_login and not self._verify_token():
-                    self._clear_auth_state()
+                    self._clear_auth_state(keep_tokenstore_path=True)
                     raise GarminConnectConnectionError(
                         f"{name}: token rejected by API tier after MFA"
                     )
@@ -471,7 +471,7 @@ class Client:
                         "%s obtained a token the API rejected; trying next strategy",
                         name,
                     )
-                    self._clear_auth_state()
+                    self._clear_auth_state(keep_tokenstore_path=True)
                     last_err = GarminConnectConnectionError(
                         f"{name}: token rejected by API tier"
                     )

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -22,10 +22,10 @@ import json
 import logging
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -735,7 +735,12 @@ class TestLoginMFA:
             c.login("e@x.com", "pw", prompt_mfa=lambda: "000000")
 
         assert c.di_token == "portal-token"  # noqa: S105
-        mock_clear.assert_called_once()
+        # One clear on login entry (fresh slate), one on the MFA token
+        # rejection before falling through to the portal strategy.
+        assert mock_clear.mock_calls == [
+            call(keep_tokenstore_path=True),
+            call(),
+        ]
 
     def test_return_on_mfa_sets_pending_flag(self):
         c = client_mod.Client(verify_login=False)
@@ -792,6 +797,78 @@ class TestLoginMFA:
 
         assert c._mfa_pending is False
         assert c._mfa_flow is None
+
+
+class TestLoginClearsStaleAuth:
+    """login() must start from a clean auth slate."""
+
+    ALL_STRATEGIES = (
+        "_mobile_login_cffi",
+        "_mobile_login_requests",
+        "_widget_web_login",
+        "_portal_web_login_cffi",
+        "_portal_web_login_requests",
+    )
+
+    def test_failed_login_clears_stale_token(self):
+        c = client_mod.Client(verify_login=False)
+        c.di_token = "STALE_DI_TOKEN_USER_A"  # noqa: S105
+
+        def fail(_email, _password):
+            raise garminconnect.GarminConnectConnectionError("skip")
+
+        with ExitStack() as stack:
+            for name in self.ALL_STRATEGIES:
+                stack.enter_context(patch.object(c, name, side_effect=fail))
+            with pytest.raises(
+                garminconnect.GarminConnectConnectionError,
+                match="All login strategies exhausted",
+            ):
+                c.login("userB@x.com", "pw")
+
+        assert c.is_authenticated is False
+        with pytest.raises(garminconnect.GarminConnectAuthenticationError):
+            c.get_api_headers()
+
+    def test_web_login_uses_fresh_jwt_not_stale_di_token(self):
+        c = client_mod.Client(verify_login=False)
+        c.di_token = "STALE_DI_TOKEN_USER_A"  # noqa: S105
+        c.skip_strategies = {
+            "mobile+cffi",
+            "mobile+requests",
+            "portal+cffi",
+            "portal+requests",
+        }
+
+        def web_login(_email, _password):
+            c.jwt_web = "FRESH_JWT_USER_B"  # noqa: S105
+
+        with patch.object(c, "_widget_web_login", side_effect=web_login):
+            c.login("userB@x.com", "pw")
+
+        assert not c.di_token
+        headers = c.get_api_headers()
+        assert headers["Cookie"] == "JWT_WEB=FRESH_JWT_USER_B"
+
+    def test_login_preserves_tokenstore_path(self):
+        c = client_mod.Client(verify_login=False)
+        c._tokenstore_path = "~/.garminconnect"
+        c.di_token = "STALE"  # noqa: S105
+        c.skip_strategies = {
+            "mobile+cffi",
+            "mobile+requests",
+            "portal+cffi",
+            "portal+requests",
+        }
+
+        def web_login(_email, _password):
+            c.di_token = "FRESH"  # noqa: S105
+
+        with patch.object(c, "_widget_web_login", side_effect=web_login):
+            c.login("userB@x.com", "pw")
+
+        assert c._tokenstore_path == "~/.garminconnect"
+        assert c.di_token == "FRESH"  # noqa: S105
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -717,6 +717,7 @@ class TestLoginMFA:
 
     def test_mfa_token_rejection_falls_through_to_next_strategy(self):
         c = client_mod.Client(verify_login=True)
+        c._tokenstore_path = "/tmp/tokenstore.json"  # noqa: S108
 
         def mfa_strategy(_email, _password):
             c._mfa_flow = "widget"
@@ -736,11 +737,36 @@ class TestLoginMFA:
 
         assert c.di_token == "portal-token"  # noqa: S105
         # One clear on login entry (fresh slate), one on the MFA token
-        # rejection before falling through to the portal strategy.
+        # rejection before falling through to the portal strategy. Both must
+        # keep the tokenstore path so the successful strategy's tokens still
+        # persist to the configured store.
         assert mock_clear.mock_calls == [
             call(keep_tokenstore_path=True),
-            call(),
+            call(keep_tokenstore_path=True),
         ]
+
+    def test_rejected_strategy_then_success_keeps_tokenstore_path(self):
+        # Real (unmocked) clears: a strategy whose token the API rejects
+        # followed by a successful strategy must retain the tokenstore path
+        # set before login, so refreshed tokens keep persisting to it.
+        c = client_mod.Client(verify_login=True)
+        c._tokenstore_path = "/tmp/tokenstore.json"  # noqa: S108
+
+        def rejected_strategy(_email, _password):
+            c.di_token = "widget-token"  # noqa: S105
+
+        def portal_strategy(_email, _password):
+            c.di_token = "portal-token"  # noqa: S105
+
+        with (
+            patch.object(c, "_widget_web_login", side_effect=rejected_strategy),
+            patch.object(c, "_portal_web_login_cffi", side_effect=portal_strategy),
+            patch.object(c, "_verify_token", side_effect=[False, True]),
+        ):
+            c.login("e@x.com", "pw")
+
+        assert c.di_token == "portal-token"  # noqa: S105
+        assert c._tokenstore_path == "/tmp/tokenstore.json"  # noqa: S108
 
     def test_return_on_mfa_sets_pending_flag(self):
         c = client_mod.Client(verify_login=False)


### PR DESCRIPTION
## Summary

From the external security audit (medium severity). `login()` never cleared previous auth state — its only entry guard checked `_mfa_pending`. A `Client` carrying an old `di_token` (from a previous login on the same instance, or a loaded token store) hit two defects:

1. **Failed login didn't clean up.** Strategy exhaustion raised without touching tokens, so `login()` throws but `is_authenticated` stays `True` and `get_api_headers()` keeps returning `Bearer <old token>`.
2. **Web login didn't displace `di_token`.** `get_api_headers()` unconditionally prefers `di_token` over `jwt_web`, and the web strategies only set `jwt_web` — so after a successful web login the fresh token was silently ignored and requests went out with the stale bearer. Worse, with `verify_login=True` (default) `_verify_token()` validated that same stale token, blessing the login as the wrong identity.

## Impact

Identity confusion / confused-deputy under Client-reuse patterns (e.g. a multi-tenant server caching Client objects — requests run as the previous user). Even single-user: a failed re-login leaves the app believing it's authenticated with dead credentials.

## Fix

- `login()` now calls `_clear_auth_state(keep_tokenstore_path=True)` at entry (after the `_mfa_pending` guard): failed logins end unauthenticated, and a web-strategy `jwt_web` can no longer be shadowed by a stale `di_token`.
- `_clear_auth_state()` gained `keep_tokenstore_path: bool = False` — the `Garmin` wrapper sets `_tokenstore_path` *before* delegating to `client.login()`, and wiping it would silently break token persistence on refresh. `logout()` behavior is unchanged (path still cleared).

## Tests

New `TestLoginClearsStaleAuth`:
- `test_failed_login_clears_stale_token` — all strategies fail → `is_authenticated` False, `get_api_headers()` raises
- `test_web_login_uses_fresh_jwt_not_stale_di_token` — stale `di_token` cleared; headers carry the fresh `JWT_WEB` cookie
- `test_login_preserves_tokenstore_path` — persistence target survives login

Updated `test_mfa_token_rejection_falls_through_to_next_strategy` for the new entry-clear call. 182 passed; only the 3 known Windows-symlink-privilege failures remain (pre-existing, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login reliability by clearing stale authentication and MFA session state before retrying.
  * Ensured fresh authentication tokens are used instead of expired or rejected credentials.
  * Preserved the configured token-store location during authentication resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->