### PR TITLE
Add health snapshot download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Make your selection:
 
 ## API Coverage Statistics
 
-- **Total API Methods**: 143+ unique endpoints (snapshot)
+- **Total API Methods**: 144+ unique endpoints (snapshot)
 - **Categories**: 13 organized sections
 - **User & Profile**: 4 methods (basic user info, settings)
 - **Daily Health & Activity**: 10 methods (today's health data plus daily calories, resting HR and sleep ranges)
@@ -62,7 +62,7 @@ Make your selection:
 - **Device & Technical**: 7 methods (device info, settings)
 - **Gear & Equipment**: 7 methods (gear management, tracking)
 - **Hydration & Wellness**: 12 methods (hydration, nutrition, blood pressure, menstrual)
-- **System & Export**: 4 methods (reporting, logout, GraphQL)
+- **System & Export**: 5 methods (reporting, logout, GraphQL, health snapshot download)
 - **Training Plans**: 3 methods (plans, plan by ID, adaptive plan by ID)
 - **Golf**: 5 methods (scorecard summary, scorecard detail, shot data, club stats, user stats)
 

--- a/demo.py
+++ b/demo.py
@@ -591,6 +591,10 @@ menu_categories = {
             },
             "3": {"desc": "Disconnect from Garmin Connect", "key": "disconnect"},
             "4": {"desc": "Execute GraphQL query", "key": "query_garmin_graphql"},
+            "5": {
+                "desc": "Download Health Snapshot ZIP for today",
+                "key": "download_health_snapshot",
+            },
         },
     },
     "b": {
@@ -4665,6 +4669,7 @@ def execute_api_call(api: Garmin, key: str) -> None:
             "create_health_report": lambda: DataExporter.create_health_report(api),
             "remove_tokens": remove_stored_tokens,
             "disconnect": lambda: disconnect_api(api),
+            "download_health_snapshot": lambda: download_health_snapshot_file(api),
             # GraphQL Queries
             "query_garmin_graphql": lambda: query_garmin_graphql_data(api),
         }
@@ -4696,6 +4701,23 @@ def disconnect_api(api: Garmin):
     """Disconnect from Garmin Connect."""
     api.logout()
     print("✅ Disconnected from Garmin Connect")
+
+
+def download_health_snapshot_file(api: Garmin):
+    """Download today's Health Snapshot ZIP and save it to the export directory."""
+    requested_date = config.today.isoformat()
+    try:
+        content = api.download_health_snapshot(requested_date)
+        if not content:
+            print("❌ No Health Snapshot content available for this date")
+            return
+        safe_date = _safe_filename_component(requested_date)
+        filepath = config.export_dir / f"{safe_date}_HEALTH_SNAPSHOT.zip"
+        with _open_private(filepath, "wb") as f:
+            f.write(content)
+        print(f"✅ Health Snapshot saved to: {filepath}")
+    except Exception as e:
+        print(f"❌ Error downloading Health Snapshot: {e}")
 
 
 def init_api(email: str | None = None, password: str | None = None) -> Garmin | None:

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -560,6 +560,7 @@ class Garmin:
         self.garmin_connect_fitnessage = "/fitnessage-service/fitnessage"
 
         self.garmin_connect_fit_download = "/download-service/files/activity"
+        self.garmin_connect_health_fit_download = "/download-service/files/wellness"
         self.garmin_connect_tcx_download = "/download-service/export/tcx/activity"
         self.garmin_connect_gpx_download = "/download-service/export/gpx/activity"
         self.garmin_connect_kml_download = "/download-service/export/kml/activity"
@@ -2849,6 +2850,15 @@ class Garmin:
         url = urls[dl_fmt]
 
         logger.debug("Downloading activity from %s", url)
+
+        return self.download(url)
+    
+    def download_health_snapshot(self, requested_date: str) -> bytes:
+        """Download the Health Snapshot ZIP file for a calendar date."""
+        requested_date = _validate_date_format(requested_date, "requested_date")
+        url = f"{self.garmin_connect_health_fit_download}/{requested_date}"
+
+        logger.debug("Downloading Health Snapshot from %s", url)
 
         return self.download(url)
 

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -560,7 +560,9 @@ class Garmin:
         self.garmin_connect_fitnessage = "/fitnessage-service/fitnessage"
 
         self.garmin_connect_fit_download = "/download-service/files/activity"
-        self.garmin_connect_health_fit_download = "/download-service/files/wellness"
+        self.garmin_connect_health_snapshot_download = (
+            "/download-service/files/wellness"
+        )
         self.garmin_connect_tcx_download = "/download-service/export/tcx/activity"
         self.garmin_connect_gpx_download = "/download-service/export/gpx/activity"
         self.garmin_connect_kml_download = "/download-service/export/kml/activity"
@@ -2858,11 +2860,11 @@ class Garmin:
         logger.debug("Downloading activity from %s", url)
 
         return self.download(url)
-    
+
     def download_health_snapshot(self, requested_date: str) -> bytes:
         """Download the Health Snapshot ZIP file for a calendar date."""
         requested_date = _validate_date_format(requested_date, "requested_date")
-        url = f"{self.garmin_connect_health_fit_download}/{requested_date}"
+        url = f"{self.garmin_connect_health_snapshot_download}/{requested_date}"
 
         logger.debug("Downloading Health Snapshot from %s", url)
 

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -157,6 +157,19 @@ def test_download_activity(garmin: garminconnect.Garmin) -> None:
 
 
 @pytest.mark.vcr
+def test_download_health_snapshot(garmin: garminconnect.Garmin) -> None:
+    garmin.login()
+
+    try:
+        snapshot = garmin.download_health_snapshot(DATE)
+        assert isinstance(snapshot, bytes)
+        assert snapshot
+    except garminconnect.GarminConnectConnectionError as e:
+        assert any(code in str(e) for code in ("403", "404", "Forbidden", "Not Found"))
+        pytest.skip("Health Snapshot unavailable for this date")
+
+
+@pytest.mark.vcr
 def test_all_day_stress(garmin: garminconnect.Garmin) -> None:
     garmin.login()
     all_day_stress = garmin.get_all_day_stress(DATE)


### PR DESCRIPTION
In __init__.py add a download_health_snapshot method that accepts as input a date, similarly to the download option on the garmin user settings page.

This pulls health snapshot "activities" that are otherwise not accessible with the normal download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading Health Snapshot data for a specified calendar date.
  * Requests validate the date format and return the snapshot as a ZIP download.
  * Added an export option for downloading today’s Health Snapshot directly from the demo interface.
  * Downloaded files use date-based filenames and are saved securely in the export directory.

* **Documentation**
  * Updated API coverage information to include Health Snapshot downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->