### PR TITLE
fix: keep pending MFA session alive after a failed resume_login() attempt

### DIFF
--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -1242,14 +1242,13 @@ class Client:
                 self._establish_session(ticket, sess=sess, service_url=svc_url)
                 return
 
-            # Non-success JSON response — could be auth failure. Log only the
-            # status, not the raw body: it may echo back request fields.
+            # Non-success JSON response — could be auth failure. The status is
+            # captured in `failures` below for the eventual exception message;
+            # no separate debug log here (data flowing through this function
+            # trips code-scanning's clear-text-logging heuristic).
             status = res.get("responseStatus", {}).get("type") or res.get(
                 "error", {}
             ).get("status-code", "unknown")
-            _LOGGER.debug(
-                "MFA verify non-success response from %s: status=%s", mfa_url, status
-            )
             failures.append(f"{mfa_url}: {status}")
 
         # All endpoints failed

--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -1242,13 +1242,14 @@ class Client:
                 self._establish_session(ticket, sess=sess, service_url=svc_url)
                 return
 
-            # Non-success JSON response — could be auth failure. Log the full
-            # response at DEBUG but keep exception messages free of sensitive
-            # SSO metadata such as serviceTicketId, customerGuid, or URLs.
-            _LOGGER.debug("MFA verify non-success response from %s: %s", mfa_url, res)
+            # Non-success JSON response — could be auth failure. Log only the
+            # status, not the raw body: it may echo back request fields.
             status = res.get("responseStatus", {}).get("type") or res.get(
                 "error", {}
             ).get("status-code", "unknown")
+            _LOGGER.debug(
+                "MFA verify non-success response from %s: status=%s", mfa_url, status
+            )
             failures.append(f"{mfa_url}: {status}")
 
         # All endpoints failed

--- a/garminconnect/client.py
+++ b/garminconnect/client.py
@@ -394,6 +394,18 @@ class Client:
         self.csrf_token = None
         if not keep_tokenstore_path:
             self._tokenstore_path = None
+        self._clear_mfa_pending_state()
+        # Drop any SSO / CAS / JWT_WEB cookies so a stale session cannot be
+        # silently refreshed after logout.
+        self.cs.cookies.clear()
+
+    def _clear_mfa_pending_state(self) -> None:
+        """Clear MFA-in-progress bookkeeping only — leaves auth tokens alone.
+
+        Used both by ``_clear_auth_state()`` (as part of a full reset) and by
+        ``resume_login()`` on success, where the just-obtained tokens must
+        survive.
+        """
         self._mfa_pending = False
         for attr in (
             "_mfa_session",
@@ -405,9 +417,6 @@ class Client:
             "_widget_last_resp",
         ):
             setattr(self, attr, None)
-        # Drop any SSO / CAS / JWT_WEB cookies so a stale session cannot be
-        # silently refreshed after logout.
-        self.cs.cookies.clear()
 
     def _verify_token(self) -> bool:
         """Check that the current token is actually accepted by the API tier.
@@ -1143,7 +1152,10 @@ class Client:
         For portal/ios flows, tries both /portal and /mobile MFA verify
         endpoints as they may be on different rate-limit buckets.
         """
-        flow = getattr(self, "_mfa_flow", "portal")
+        # getattr's default only applies when the attribute is absent, not
+        # when it's present-but-None (e.g. right after a state reset) — the
+        # `or` catches that case too.
+        flow = getattr(self, "_mfa_flow", None) or "portal"
         if flow == "widget":
             self._complete_mfa_widget(mfa_code)
             return
@@ -1606,29 +1618,19 @@ class Client:
         return resp
 
     def resume_login(self, _client_state: Any, mfa_code: str) -> tuple[str | None, Any]:
-        """Complete a previously initiated MFA login."""
-        try:
-            self._complete_mfa(mfa_code)
-            if self.verify_login and not self._verify_token():
-                self._clear_auth_state()
-                raise GarminConnectConnectionError(
-                    "token rejected by API tier after MFA"
-                )
-            return None, None
-        finally:
-            # Always clear the pending MFA flag and per-attempt state so a new
-            # login can start after resume_login() finishes (success or failure).
-            self._mfa_pending = False
-            for attr in (
-                "_mfa_session",
-                "_mfa_login_params",
-                "_mfa_post_headers",
-                "_mfa_service_url",
-                "_mfa_flow",
-                "_mfa_method",
-                "_widget_last_resp",
-            ):
-                setattr(self, attr, None)
+        """Complete a previously initiated MFA login.
+
+        A failed verification code (or a rate-limited attempt) leaves the
+        pending MFA session intact so the caller can retry with a corrected
+        code on the same instance. Only success, or a non-retryable failure
+        after MFA itself succeeded, clears the pending state.
+        """
+        self._complete_mfa(mfa_code)
+        if self.verify_login and not self._verify_token():
+            self._clear_auth_state()
+            raise GarminConnectConnectionError("token rejected by API tier after MFA")
+        self._clear_mfa_pending_state()
+        return None, None
 
     def download(self, path: str, **kwargs: Any) -> bytes:
         if "headers" not in kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garminconnect"
-version = "0.3.11"
+version = "0.3.12"
 description = "Python 3 API wrapper for Garmin Connect"
 authors = [
     {name = "Ron Klinkien", email = "ron@cyberjunky.nl"},

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -643,6 +643,37 @@ class TestResumeLogin:
         mock_complete.assert_called_once_with("123456")
         mock_verify.assert_not_called()
 
+    def test_client_resume_login_keeps_session_on_wrong_code_for_retry(self):
+        """A failed verification code must not wipe the pending MFA session —
+        otherwise a retry with the correct code can never succeed (issue 416).
+        """
+        c = client_mod.Client(verify_login=False)
+        c._mfa_pending = True
+        c._mfa_session = object()
+        c._mfa_flow = "portal"
+        c._mfa_method = "email"
+
+        with (
+            patch.object(
+                c,
+                "_complete_mfa",
+                side_effect=garminconnect.GarminConnectAuthenticationError("bad code"),
+            ),
+            pytest.raises(garminconnect.GarminConnectAuthenticationError),
+        ):
+            c.resume_login({}, "000000")
+
+        assert c._mfa_pending is True
+        assert c._mfa_session is not None
+        assert c._mfa_flow == "portal"
+        assert c._mfa_method == "email"
+
+        # Retry with the correct code on the same instance now succeeds.
+        with patch.object(c, "_complete_mfa") as mock_complete:
+            assert c.resume_login({}, "123456") == (None, None)
+        mock_complete.assert_called_once_with("123456")
+        assert c._mfa_pending is False
+
     def test_garmin_resume_login_propagates_profile_load_failure(self):
         g = garminconnect.Garmin("user@example.com", "secret")
         with (


### PR DESCRIPTION
## Summary
- `resume_login()` unconditionally wiped the pending MFA session in a `finally` block, even when `_complete_mfa()` failed — a wrong-code retry could never succeed because the second call hit a cleared session and surfaced as an indistinguishable auth failure.
- The pending state is now only cleared on success or on a non-retryable failure (token rejected after MFA already succeeded); a failed verification attempt leaves the session intact so the caller can retry with a corrected code on the same client instance.
- Also fixes `_mfa_flow`'s `getattr` default not applying once the attribute is present-but-`None`, which produced a malformed `sso.garmin.com/None/...` verify URL.
- Bumps version to 0.3.12.

Closes #416

## Test plan
- [x] `python -m pytest tests/test_garmin_unit.py -q` (223 passed)
- [x] Added `test_client_resume_login_keeps_session_on_wrong_code_for_retry` covering the retry-after-wrong-code path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-factor authentication retry handling after an incorrect verification code, allowing another attempt without restarting sign-in.
  * Ensured authentication state and related session data are fully cleared when required.
  * Improved fallback handling for portal-based verification flows.
  * Reduced sensitive detail in MFA verification logs.

* **Chores**
  * Updated the project version to 0.3.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->