### PR TITLE
feat: add activitysubtype filter

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -2123,17 +2123,9 @@ def get_activity_exercise_sets_data(api: Garmin) -> None:
     """Get exercise sets for strength training activities."""
     try:
         activities = api.get_activities(
-            0, 20
+            0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
         )  # Get more activities to find a strength training one
-        strength_activity = None
-
-        # Find strength training activities
-        for activity in activities:
-            activity_type = activity.get("activityType", {})
-            type_key = activity_type.get("typeKey", "")
-            if "strength" in type_key.lower() or "training" in type_key.lower():
-                strength_activity = activity
-                break
+        strength_activity = activities[0] if activities else None
 
         if strength_activity:
             activity_id = strength_activity["activityId"]
@@ -3619,13 +3611,10 @@ def set_activity_exercise_sets_data(api: Garmin) -> None:
     is a safe no-op that proves the endpoint without altering the activity.
     """
     try:
-        activities = api.get_activities(0, 20)
-        strength_activity = None
-        for activity in activities:
-            type_key = activity.get("activityType", {}).get("typeKey", "")
-            if "strength" in type_key.lower() or "training" in type_key.lower():
-                strength_activity = activity
-                break
+        activities = api.get_activities(
+            0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
+        )
+        strength_activity = activities[0] if activities else None
 
         if not strength_activity:
             print("ℹ️ No strength training activities found")

--- a/demo.py
+++ b/demo.py
@@ -2125,7 +2125,12 @@ def get_activity_exercise_sets_data(api: Garmin) -> None:
         activities = api.get_activities(
             0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
         )
-        strength_activity = activities[0] if activities and isinstance(activities, list) else None
+        activity_list = (
+            activities.get("activityList", [])
+            if isinstance(activities, dict)
+            else activities
+        )
+        strength_activity = activity_list[0] if activity_list else None
 
         if strength_activity:
             activity_id = strength_activity["activityId"]
@@ -3614,7 +3619,12 @@ def set_activity_exercise_sets_data(api: Garmin) -> None:
         activities = api.get_activities(
             0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
         )
-        strength_activity = activities[0] if activities and isinstance(activities, list) else None
+        activity_list = (
+            activities.get("activityList", [])
+            if isinstance(activities, dict)
+            else activities
+        )
+        strength_activity = activity_list[0] if activity_list else None
 
         if not strength_activity:
             print("ℹ️ No strength training activities found")

--- a/demo.py
+++ b/demo.py
@@ -2124,8 +2124,8 @@ def get_activity_exercise_sets_data(api: Garmin) -> None:
     try:
         activities = api.get_activities(
             0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
-        )  # Get more activities to find a strength training one
-        strength_activity = activities[0] if activities else None
+        )
+        strength_activity = activities[0] if activities and isinstance(activities, list) else None
 
         if strength_activity:
             activity_id = strength_activity["activityId"]
@@ -3614,7 +3614,7 @@ def set_activity_exercise_sets_data(api: Garmin) -> None:
         activities = api.get_activities(
             0, 1, activitytype="fitness_equipment", activitysubtype="strength_training"
         )
-        strength_activity = activities[0] if activities else None
+        strength_activity = activities[0] if activities and isinstance(activities, list) else None
 
         if not strength_activity:
             print("ℹ️ No strength training activities found")

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -2336,11 +2336,13 @@ class Garmin:
         start: int = 0,
         limit: int = 20,
         activitytype: str | None = None,
+        activitysubtype: str | None = None,
     ) -> dict[str, Any] | list[Any]:
         """Return available activities.
         :param start: Starting activity offset, where 0 means the most recent activity
         :param limit: Number of activities to return
         :param activitytype: (Optional) Filter activities by type
+        :param activitysubtype: (Optional) Filter activities further by sub-type.
         :return: List of activities from Garmin.
         """
         # Validate inputs
@@ -2354,6 +2356,9 @@ class Garmin:
         params = {"start": str(start), "limit": str(limit)}
         if activitytype:
             params["activityType"] = activitytype
+
+            if activitysubtype:
+                params["activitySubType"] = activitysubtype
 
         logger.debug("Requesting activities from %d with limit %d", start, limit)
 

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -1524,6 +1524,19 @@ class TestParameterLimits:
         params = mock.call_args.kwargs["params"]
         assert params["activityType"] == "running"
 
+    def test_get_activities_passes_activitysubtype(self, garmin: garminconnect.Garmin):
+        with patch.object(garmin, "connectapi", return_value=[]) as mock:
+            garmin.get_activities(
+                start=0,
+                limit=5,
+                activitytype="fitness_equipment",
+                activitysubtype="strength_training",
+            )
+
+            params = mock.call_args.kwargs["params"]
+            assert params["activityType"] == "fitness_equipment"
+            assert params["activitySubType"] == "strength_training"
+
     def test_get_activities_returns_empty_list_when_api_returns_none(
         self, garmin: garminconnect.Garmin
     ):


### PR DESCRIPTION
## Summary

Adding new `activitysubtype` parameter to the `GarminConnect.get_activities` method. This gives callers the option of filtering for specific activity subtypes via the api instead of manually filtering after retrieving the broader activity list.

### Validations

- Ensured relevant tests passed
- Confirmed formatter/linter passed for modified code blocks[^1].
- Updated `demo.py` to use new filters and manually verified results.

[^1]: There were several other changes to unrelated files after running the formatter, but I didn't include them. I wanted to keep this PR focused on one thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity searches now support filtering by activity subtype.
  * Strength-training activity searches use dedicated activity type and subtype filters for more targeted results.

* **Bug Fixes**
  * Strength-training activity selection now provides more focused results by avoiding broad result matching.

* **Tests**
  * Added coverage to verify activity subtype filters are correctly sent when retrieving activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->