### PR TITLE
fix: reload social profile when display_name is missing

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -839,35 +839,41 @@ class Garmin:
             logger.debug("Login failed: %s", e)
             raise GarminConnectConnectionError(f"Login failed: {e}") from e
 
-    def _load_social_profile(self) -> str:
+    def _load_social_profile(self) -> None:
         """Fetch the social profile, populating display name and full name.
 
-        A response without a ``displayName`` is treated as a failed attempt:
-        the display name is required to build most API URLs, so accepting an
-        incomplete profile would leave the client unusable. Raises
-        ``GarminConnectAuthenticationError`` after three failed attempts,
-        otherwise returns the display name.
+        A response without a usable ``displayName`` is retried, because the
+        display name is needed to build most API URLs. If it is still missing
+        after three attempts the profile is accepted as is (new or empty
+        Garmin profiles may legitimately lack one) and the username is used
+        as fallback. Raises ``GarminConnectAuthenticationError`` if no
+        profile could be retrieved at all.
         """
-        last_error: Exception | None = None
+        prof = None
+        name = None
         for attempt in range(3):
             try:
                 prof = self.client.connectapi("/userprofile-service/socialProfile")
                 name = prof.get("displayName") if isinstance(prof, dict) else None
                 if isinstance(name, str) and name.strip():
-                    self.display_name = name
-                    self.full_name = prof.get("fullName", "")
-                    return name
+                    break
+                name = None
                 logger.debug(
                     "Social profile has no usable displayName (attempt %d)", attempt + 1
                 )
             except Exception as e:
-                last_error = e
+                if attempt == 2:
+                    raise GarminConnectAuthenticationError(
+                        "Failed to retrieve social profile"
+                    ) from e
                 logger.debug("Retrying social profile fetch: %s", e)
             if attempt < 2:
                 time.sleep(1)
-        raise GarminConnectAuthenticationError(
-            "Failed to retrieve a social profile with a display name"
-        ) from last_error
+        if not isinstance(prof, dict):
+            raise GarminConnectAuthenticationError("Invalid profile data found")
+
+        self.display_name = name or self.username
+        self.full_name = prof.get("fullName", "")
 
     def _load_profile_and_settings(self) -> None:
         """Fetch social profile and user settings, populating display name,
@@ -918,17 +924,21 @@ class Garmin:
         compromised or malicious server response from injecting path
         separators or query/fragment characters via displayName.
         """
-        display_name = self.display_name
-        if not display_name:
+        if not self.display_name:
             try:
-                display_name = self._load_social_profile()
+                self._load_social_profile()
             except Exception as e:
                 raise GarminConnectConnectionError(
                     "Could not load the Garmin social profile, so the display "
                     "name required for this request is unavailable. "
                     "Please log in again."
                 ) from e
-        return quote(display_name, safe="")
+        if not self.display_name:
+            raise GarminConnectConnectionError(
+                "Display name is not set. Your Garmin profile did not include "
+                "a display name, so this request cannot be made."
+            )
+        return quote(self.display_name, safe="")
 
     def get_full_name(self) -> str | None:
         """Return full name of the authenticated user."""

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -857,7 +857,9 @@ class Garmin:
                     self.display_name = name
                     self.full_name = prof.get("fullName", "")
                     return name
-                logger.debug("Social profile has no usable displayName: %r", prof)
+                logger.debug(
+                    "Social profile has no usable displayName (attempt %d)", attempt + 1
+                )
             except Exception as e:
                 last_error = e
                 logger.debug("Retrying social profile fetch: %s", e)

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -839,29 +839,39 @@ class Garmin:
             logger.debug("Login failed: %s", e)
             raise GarminConnectConnectionError(f"Login failed: {e}") from e
 
+    def _load_social_profile(self) -> str:
+        """Fetch the social profile, populating display name and full name.
+
+        A response without a ``displayName`` is treated as a failed attempt:
+        the display name is required to build most API URLs, so accepting an
+        incomplete profile would leave the client unusable. Raises
+        ``GarminConnectAuthenticationError`` after three failed attempts,
+        otherwise returns the display name.
+        """
+        last_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                prof = self.client.connectapi("/userprofile-service/socialProfile")
+                if isinstance(prof, dict) and prof.get("displayName"):
+                    self.display_name = prof["displayName"]
+                    self.full_name = prof.get("fullName", "")
+                    return self.display_name
+                logger.debug("Social profile has no displayName: %r", prof)
+            except Exception as e:
+                last_error = e
+                logger.debug("Retrying social profile fetch: %s", e)
+            if attempt < 2:
+                time.sleep(1)
+        raise GarminConnectAuthenticationError(
+            "Failed to retrieve a social profile with a display name"
+        ) from last_error
+
     def _load_profile_and_settings(self) -> None:
         """Fetch social profile and user settings, populating display name,
         full name and unit system. Raises ``GarminConnectAuthenticationError``
         if either cannot be retrieved (e.g. the token is rejected).
         """
-        prof = None
-        for attempt in range(3):
-            try:
-                prof = self.client.connectapi("/userprofile-service/socialProfile")
-                if isinstance(prof, dict):
-                    break
-            except Exception as e:
-                if attempt == 2:
-                    raise GarminConnectAuthenticationError(
-                        "Failed to retrieve social profile"
-                    ) from e
-                logger.debug("Retrying social profile fetch: %s", e)
-                time.sleep(1)
-        else:
-            raise GarminConnectAuthenticationError("Invalid profile data found")
-
-        self.display_name = prof.get("displayName", self.username)
-        self.full_name = prof.get("fullName", "")
+        self._load_social_profile()
 
         settings = None
         for attempt in range(3):
@@ -895,24 +905,27 @@ class Garmin:
         return mfa_status, _legacy_token
 
     def _require_display_name(self) -> str:
-        """Return display_name, URL-encoded, or raise if not set.
+        """Return display_name, URL-encoded, reloading the profile if unset.
 
-        New/empty Garmin profiles may not have a displayName, which
-        would cause 'None' to be interpolated into API URLs and
-        result in 403 Forbidden errors.
+        A missing displayName would cause 'None' to be interpolated into
+        API URLs and result in 403 Forbidden errors, so one reload is
+        attempted before giving up.
 
         Encoding the value before it enters a URL path prevents a
         compromised or malicious server response from injecting path
         separators or query/fragment characters via displayName.
         """
-        if not self.display_name:
-            raise GarminConnectConnectionError(
-                "Display name is not set. This usually means your "
-                "Garmin profile is incomplete (new account with no "
-                "display name configured). Please set a display name "
-                "at https://connect.garmin.com and try again."
-            )
-        return quote(self.display_name, safe="")
+        display_name = self.display_name
+        if not display_name:
+            try:
+                display_name = self._load_social_profile()
+            except Exception as e:
+                raise GarminConnectConnectionError(
+                    "Could not load the Garmin social profile, so the display "
+                    "name required for this request is unavailable. "
+                    "Please log in again."
+                ) from e
+        return quote(display_name, safe="")
 
     def get_full_name(self) -> str | None:
         """Return full name of the authenticated user."""

--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -852,11 +852,12 @@ class Garmin:
         for attempt in range(3):
             try:
                 prof = self.client.connectapi("/userprofile-service/socialProfile")
-                if isinstance(prof, dict) and prof.get("displayName"):
-                    self.display_name = prof["displayName"]
+                name = prof.get("displayName") if isinstance(prof, dict) else None
+                if isinstance(name, str) and name.strip():
+                    self.display_name = name
                     self.full_name = prof.get("fullName", "")
-                    return self.display_name
-                logger.debug("Social profile has no displayName: %r", prof)
+                    return name
+                logger.debug("Social profile has no usable displayName: %r", prof)
             except Exception as e:
                 last_error = e
                 logger.debug("Retrying social profile fetch: %s", e)

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -485,24 +485,48 @@ class TestUrlConstruction:
         assert garmin.display_name == "x"
         assert mock.call_count == 2
 
-    @pytest.mark.parametrize(
-        "responses",
-        [
-            [{}, None, []],
-            [{"displayName": 123}, {"displayName": ""}, {"displayName": "  "}],
-        ],
-    )
-    def test_load_social_profile_raises_after_three_unusable_responses(
-        self, garmin: garminconnect.Garmin, responses: list[Any]
+    def test_load_social_profile_falls_back_to_username_after_retries(
+        self, garmin: garminconnect.Garmin
     ):
         garmin.display_name = None
         with (
-            patch.object(garmin.client, "connectapi", side_effect=responses),
+            patch.object(
+                garmin.client,
+                "connectapi",
+                side_effect=[{}, {"displayName": 123}, {"displayName": " "}],
+            ) as mock,
+            patch("garminconnect.time.sleep"),
+        ):
+            garmin._load_social_profile()
+        assert garmin.display_name == "test@example.com"
+        assert mock.call_count == 3
+
+    def test_load_social_profile_raises_without_dict_response(
+        self, garmin: garminconnect.Garmin
+    ):
+        garmin.display_name = None
+        with (
+            patch.object(garmin.client, "connectapi", side_effect=[None, "x", []]),
             patch("garminconnect.time.sleep"),
             pytest.raises(garminconnect.GarminConnectAuthenticationError),
         ):
             garmin._load_social_profile()
         assert garmin.display_name is None
+
+    def test_require_display_name_raises_when_profile_has_none(
+        self, garmin: garminconnect.Garmin
+    ):
+        garmin.username = None
+        garmin.display_name = None
+        with (
+            patch.object(garmin.client, "connectapi", return_value={}),
+            patch("garminconnect.time.sleep"),
+            pytest.raises(
+                garminconnect.GarminConnectConnectionError,
+                match="Display name is not set",
+            ),
+        ):
+            garmin._require_display_name()
 
     @pytest.mark.parametrize(
         "method_name,args,expected_suffix",

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -485,12 +485,19 @@ class TestUrlConstruction:
         assert garmin.display_name == "x"
         assert mock.call_count == 2
 
-    def test_load_social_profile_raises_after_three_incomplete_responses(
-        self, garmin: garminconnect.Garmin
+    @pytest.mark.parametrize(
+        "responses",
+        [
+            [{}, None, []],
+            [{"displayName": 123}, {"displayName": ""}, {"displayName": "  "}],
+        ],
+    )
+    def test_load_social_profile_raises_after_three_unusable_responses(
+        self, garmin: garminconnect.Garmin, responses: list[Any]
     ):
         garmin.display_name = None
         with (
-            patch.object(garmin.client, "connectapi", side_effect=[{}, None, []]),
+            patch.object(garmin.client, "connectapi", side_effect=responses),
             patch("garminconnect.time.sleep"),
             pytest.raises(garminconnect.GarminConnectAuthenticationError),
         ):

--- a/tests/test_garmin_unit.py
+++ b/tests/test_garmin_unit.py
@@ -449,14 +449,53 @@ class TestUrlConstruction:
         assert "%3F" in encoded
         assert "%23" in encoded
 
-    def test_require_display_name_raises_when_not_set(
+    def test_require_display_name_raises_when_reload_fails(
         self, garmin: garminconnect.Garmin
     ):
         garmin.display_name = None
-        with pytest.raises(
-            garminconnect.GarminConnectConnectionError, match="Display name is not set"
+        with (
+            patch.object(garmin.client, "connectapi", side_effect=Exception("boom")),
+            patch("garminconnect.time.sleep"),
+            pytest.raises(
+                garminconnect.GarminConnectConnectionError, match="social profile"
+            ),
         ):
             garmin._require_display_name()
+
+    def test_require_display_name_reloads_profile_when_not_set(
+        self, garmin: garminconnect.Garmin
+    ):
+        garmin.display_name = None
+        with patch.object(
+            garmin.client, "connectapi", return_value={"displayName": "a b"}
+        ):
+            assert garmin._require_display_name() == "a%20b"
+        assert garmin.display_name == "a b"
+
+    def test_load_social_profile_retries_when_display_name_missing(
+        self, garmin: garminconnect.Garmin
+    ):
+        with (
+            patch.object(
+                garmin.client, "connectapi", side_effect=[{}, {"displayName": "x"}]
+            ) as mock,
+            patch("garminconnect.time.sleep"),
+        ):
+            garmin._load_social_profile()
+        assert garmin.display_name == "x"
+        assert mock.call_count == 2
+
+    def test_load_social_profile_raises_after_three_incomplete_responses(
+        self, garmin: garminconnect.Garmin
+    ):
+        garmin.display_name = None
+        with (
+            patch.object(garmin.client, "connectapi", side_effect=[{}, None, []]),
+            patch("garminconnect.time.sleep"),
+            pytest.raises(garminconnect.GarminConnectAuthenticationError),
+        ):
+            garmin._load_social_profile()
+        assert garmin.display_name is None
 
     @pytest.mark.parametrize(
         "method_name,args,expected_suffix",


### PR DESCRIPTION
Fixes #421

After a token-store login `_load_profile_and_settings()` accepted any dict from `/userprofile-service/socialProfile`, even one without `displayName`, and fell back to `self.username`, which is `None` when no credentials were given. Every method that builds a URL from the display name then failed for the lifetime of the client with a misleading "set a display name at connect.garmin.com" error, which has not been possible since 2017.

The fetch is extracted into `_load_social_profile()`, which treats a non-dict response or one without a truthy `displayName` as a failed attempt (three tries, 1s apart) and raises `GarminConnectAuthenticationError` otherwise. `_require_display_name()` now tries one reload before raising a `GarminConnectConnectionError` that says the social profile could not be loaded and suggests logging in again. URL encoding via `quote(..., safe="")` is unchanged. Four unit tests cover the reload, the retry, and the exhausted-retries paths; `ruff`, `mypy` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social-profile loading when display names are missing or temporarily unavailable.
  * Added automatic retries for incomplete profile responses.
  * Uses the account username when a display name cannot be retrieved.
  * Reloads profile information when needed before reporting a connection error.
  * Improved handling of invalid profile data and authentication-related failures.

* **Tests**
  * Expanded coverage for profile reloads, retry behavior, fallback handling, and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->