### PR TITLE
docs: document personal records schema and running typeId mapping in get_personal_record

### DIFF
--- a/garminconnect/__init__.py
+++ b/garminconnect/__init__.py
@@ -1793,7 +1793,19 @@ class Garmin:
         return self.connectapi(url, params={"calendarDate": cdate})
 
     def get_personal_record(self) -> dict[str, Any]:
-        """Return personal records for current user."""
+        """Return personal records for current user.
+
+        Returns raw personal record entries from Garmin Connect.
+        For running records (activityType == 'running'), typeId maps to:
+          - 1: 1 km
+          - 2: 1 mile
+          - 3: 5 km
+          - 4: 10 km
+          - 5: Half marathon
+          - 6: Marathon
+          - 7: Longest run (distance in meters; duration requires
+            calling activity-service/activity/{activityId})
+        """
         url = (
             f"{self.garmin_connect_personal_record_url}/{self._require_display_name()}"
         )


### PR DESCRIPTION
### Description
This PR enriches the docstring of `get_personal_record()` in `garminconnect/__init__.py` to document the structure and identifiers returned by the Garmin Connect API.

### Changes
- Documented the mapping of running `typeId` values (1 to 7) based on real-world Garmin Connect payloads.
- Added a note explaining that `longestRun` (`typeId: 7`) returns distance in meters in `value`, and that retrieving duration requires fetching the activity details via `activity-service/activity/{activityId}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the `get_personal_record` documentation to describe returned personal record entries.
  - Documented running record types, including distances from 1 km through marathon and longest run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->