### PR TITLE
fix: read sleep respiration average from the correct API field

### DIFF
--- a/garminconnect/typed.py
+++ b/garminconnect/typed.py
@@ -214,7 +214,7 @@ class DailySleepDTO(_BaseResponse):
     avg_sleep_hrv: float | None = Field(default=None, alias="avgSleepHRV")
     avg_spo2: float | None = Field(default=None, alias="avgSpO2")
     avg_respiration_value: float | None = Field(
-        default=None, alias="avgRespirationValue"
+        default=None, alias="averageRespirationValue"
     )
     lowest_respiration_value: float | None = Field(
         default=None, alias="lowestRespirationValue"

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -91,7 +91,7 @@ SAMPLE_SLEEP_DATA: dict = {
         "sleepEndTimestampGMT": 1761125400000,
         "avgSleepHRV": 52.3,
         "avgSpO2": 96.0,
-        "avgRespirationValue": 14.2,
+        "averageRespirationValue": 14.2,
         "sleepScores": {
             "overall": {"value": 84, "qualifierKey": "GOOD"},
             "totalDuration": {"value": 90, "qualifierKey": "EXCELLENT"},
@@ -242,6 +242,7 @@ def test_get_sleep_data_returns_nested_dto(garmin: garminconnect.Garmin) -> None
     assert sleep.daily_sleep_dto.sleep_time_seconds == 25200
     assert sleep.daily_sleep_dto.deep_sleep_seconds == 5400
     assert sleep.daily_sleep_dto.avg_sleep_hrv == 52.3
+    assert sleep.daily_sleep_dto.avg_respiration_value == 14.2
     # Nested scores are also typed
     assert sleep.daily_sleep_dto.sleep_scores is not None
     assert sleep.daily_sleep_dto.sleep_scores.overall is not None


### PR DESCRIPTION
### Summary
`DailySleepDTO.avg_respiration_value` is aliased to `"avgRespirationValue"`, which never matches a real Garmin response — the sleep-service `dailySleepData` endpoint nests the sleep-window average under **`averageRespirationValue`**. `lowestRespirationValue`/`highestRespirationValue` were already correct; only the average was wrong.

Found and confirmed live via a debug-log capture in [cyberjunky/home-assistant-garmin_connect's](https://github.com/cyberjunky/home-assistant-garmin_connect) `ha-garmin` client, which had the exact same bug (same field, same wrong name) — fixed there in [cyberjunky/ha-garmin#28](https://github.com/cyberjunky/ha-garmin/pull/28). Real response had `'averageRespirationValue': 15.0` alongside working `deepSleepSeconds`, `sleepScores`, etc., proving the endpoint itself is fine and only this one field alias was wrong.

### Fix
Alias corrected to `averageRespirationValue`. Test fixture/assertion updated to match the real field name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected sleep data parsing for average respiration values, ensuring the reported value is displayed accurately.

- **Tests**
  - Updated sleep data validation to reflect the corrected respiration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->