### PR TITLE
fix: stop demo.py's menu dispatch from needing a hardcoded key whitelist

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -5173,10 +5173,14 @@ def main():
                 print_category_menu(current_category)
                 option = safe_readkey()
 
-                # Handle category menu options
+                # Handle category menu options. Validity is decided solely by
+                # membership in the current category's own options dict —
+                # no separate hardcoded character whitelist to keep in sync
+                # whenever a new option key (e.g. an uppercase letter) is
+                # added to menu_categories.
                 if option == "q":
                     current_category = None  # Back to main menu
-                elif option in "0123456789abcdefghijklmnopqrstuvwxyzA":
+                else:
                     try:
                         category_data = menu_categories[current_category]
                         category_options = category_data["options"]
@@ -5190,10 +5194,6 @@ def main():
                             )
                     except Exception as e:
                         print(f"❌ Error processing option {option}: {e}")
-                else:
-                    print(
-                        "❌ Invalid selection. Use numbers/letters for options or 'q' to go back/quit"
-                    )
 
         except KeyboardInterrupt:
             print("\nInterrupted by user. Press q to quit.")


### PR DESCRIPTION
## Summary
Pressing `[B]` for the new "Get the earliest upcoming scheduled workout" menu option (added in #429) printed "❌ Invalid selection" instead of running it — `demo.py`'s category-menu dispatch checked the pressed key against a literal `"0123456789abc...xyzA"` string *before* ever consulting the category's own options dict, and that string was never updated for the new `B` key.

Removed the whitelist entirely. The `if option in category_options` check right below it already validates correctly against the real menu (by construction, since it's the same dict driving what's printed on screen), and its error message already lists the real valid keys for that category — nothing is lost, and no future option key can go stale again.

## Test plan
- [x] `python -m pytest -q` (381 passed)
- [x] `ruff check` / `ruff format --check` / `mypy` all clean
- [x] Simulated the dispatch loop directly: `B` → `get_next_scheduled_workout`, `A` → `get_activities_filtered`, an existing lowercase key still works, and a genuinely invalid key now prints the accurate list of valid options instead of a generic message